### PR TITLE
feat(Globus Auth): adds support for the Identities resources in the Globus Auth API

### DIFF
--- a/src/lib/services/auth/__tests__/identities.spec.ts
+++ b/src/lib/services/auth/__tests__/identities.spec.ts
@@ -1,0 +1,94 @@
+import { identities } from "..";
+import { createStorage } from "../../../core/storage";
+
+import type { MirroredRequest } from "../../../../../mocks/handlers";
+
+test("get", async () => {
+  createStorage("memory");
+  const result = await identities.get("6521a0c3-ffc9-4432-9cb6-41fa8fe2e4e9");
+  const {
+    req: { url, method, headers },
+  } = (await result.json()) as unknown as MirroredRequest;
+
+  expect({
+    url,
+    method,
+    headers,
+  }).toMatchInlineSnapshot(`
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "auth.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://auth.globus.org/identities/6521a0c3-ffc9-4432-9cb6-41fa8fe2e4e9",
+}
+`);
+});
+
+test("getAll", async () => {
+  createStorage("memory");
+  const result = await identities.getAll({
+    query: {
+      ids: "538e096f-0468-4d54-8463-50af72c01f95,1e1cac10-b303-48d8-aa81-3b3a592a2564",
+    },
+  });
+  const {
+    req: { url, method, headers },
+  } = (await result.json()) as unknown as MirroredRequest;
+
+  expect({
+    url,
+    method,
+    headers,
+  }).toMatchInlineSnapshot(`
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "auth.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://auth.globus.org/identities?ids=538e096f-0468-4d54-8463-50af72c01f95%2C1e1cac10-b303-48d8-aa81-3b3a592a2564",
+}
+`);
+});
+
+test("getAll – with 'include'", async () => {
+  createStorage("memory");
+  const result = await identities.getAll({
+    query: {
+      ids: [
+        "538e096f-0468-4d54-8463-50af72c01f95",
+        "1e1cac10-b303-48d8-aa81-3b3a592a2564",
+      ],
+      include: "identity_provider",
+    },
+  });
+  const {
+    req: { url, method, headers },
+  } = (await result.json()) as unknown as MirroredRequest;
+
+  expect({
+    url,
+    method,
+    headers,
+  }).toMatchInlineSnapshot(`
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "auth.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://auth.globus.org/identities?ids=538e096f-0468-4d54-8463-50af72c01f95%2C1e1cac10-b303-48d8-aa81-3b3a592a2564&include=identity_provider",
+}
+`);
+});

--- a/src/lib/services/auth/config.ts
+++ b/src/lib/services/auth/config.ts
@@ -9,3 +9,7 @@ export const HOSTS: Partial<Record<Environment, string>> = {
   staging: "auth.staging.globuscs.info",
   preview: "auth.preview.globus.org",
 };
+
+export const SCOPES = {
+  VIEW_IDENTITIES: "urn:globus:auth:scope:auth.globus.org:view_identities",
+};

--- a/src/lib/services/auth/index.ts
+++ b/src/lib/services/auth/index.ts
@@ -24,6 +24,8 @@ export function getTokenEndpoint() {
   return build(AUTH.ID, "/v2/oauth2/token");
 }
 
+export * as identities from "./service/identities.js";
+
 export type Token = ITokenResponse & {
   resource_server: string;
   id_token?: string;

--- a/src/lib/services/auth/service/identities.ts
+++ b/src/lib/services/auth/service/identities.ts
@@ -1,0 +1,46 @@
+import { ID, SCOPES } from "../config.js";
+import { serviceRequest } from "../../../services/shared.js";
+
+import type {
+  ServiceMethod,
+  ServiceMethodDynamicSegments,
+} from "../../types.js";
+
+/**
+ * Fetch a single Identity by ID.
+ * @see https://docs.globus.org/api/auth/reference/#get_identities
+ */
+export const get = function (identity_id, options = {}, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.VIEW_IDENTITIES,
+      path: `/identities/${identity_id}`,
+    },
+    options,
+    sdkOptions
+  );
+} satisfies ServiceMethodDynamicSegments<string, Record<string, any>>;
+
+/**
+ * Return a list of identities that match provided query parameters.
+ * @see https://docs.globus.org/api/auth/reference/#get_identities
+ */
+export const getAll = function (options = {}, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.VIEW_IDENTITIES,
+      path: `/identities`,
+    },
+    options,
+    sdkOptions
+  );
+} satisfies ServiceMethod<{
+  query?: {
+    ids?: string | string[];
+    usernames?: string | string[];
+  };
+  headers?: Record<string, string>;
+  payload?: never;
+}>;


### PR DESCRIPTION
- Adds support for fetching a single identity (by UUID) and list – https://docs.globus.org/api/auth/reference/#identities_api