### PR TITLE
feat(Transfer): adds Task-related service methods, endpoint.remove, and updates to shared scope constant.

### DIFF
--- a/src/lib/services/transfer/__tests__/__snapshots__/endpoint.spec.ts.snap
+++ b/src/lib/services/transfer/__tests__/__snapshots__/endpoint.spec.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`endpoint delete 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "DELETE",
+  "url": "https://transfer.api.globusonline.org/v0.10/endpoint/c591c905-2674-4227-9d31-1ff9485945a7",
+}
+`;
+
+exports[`endpoint get 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/endpoint/c591c905-2674-4227-9d31-1ff9485945a7",
+}
+`;

--- a/src/lib/services/transfer/__tests__/__snapshots__/task.spec.ts.snap
+++ b/src/lib/services/transfer/__tests__/__snapshots__/task.spec.ts.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`task cancel 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "0",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "POST",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/cancel",
+}
+`;
+
+exports[`task get 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id",
+}
+`;
+
+exports[`task getAll 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task_list",
+}
+`;
+
+exports[`task getEventList 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/event_list?filters=iserror%3A1",
+}
+`;
+
+exports[`task getPauseInfo 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/pause_info",
+}
+`;
+
+exports[`task getSkippedErrors 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/skipped_errors?marker=10",
+}
+`;
+
+exports[`task getSuccessfulTransfers 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "GET",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/successful_transfers?marker=1",
+}
+`;
+
+exports[`task remove 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "0",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": undefined,
+  "method": "POST",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id/remove",
+}
+`;
+
+exports[`task update 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "24",
+    "content-type": "application/json",
+    "host": "transfer.api.globusonline.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": {
+    "label": "A new label.",
+  },
+  "method": "PUT",
+  "url": "https://transfer.api.globusonline.org/v0.10/task/example-task-id",
+}
+`;

--- a/src/lib/services/transfer/__tests__/endpoint.spec.ts
+++ b/src/lib/services/transfer/__tests__/endpoint.spec.ts
@@ -1,17 +1,33 @@
-import serviceTestSuite from '../../../../__utils__/service-test-suite';
+import { createStorage } from '../../../core/storage';
 import { endpoint } from '..';
+import { mirror } from '../../../../__mocks__/handlers';
 
 const ENDPOINT = 'c591c905-2674-4227-9d31-1ff9485945a7';
 
-serviceTestSuite('transfer', 'endpoint', (fetch) => {
+describe('endpoint', () => {
+  beforeEach(() => {
+    createStorage('memory');
+  });
+
   test('get', async () => {
-    await endpoint.get(ENDPOINT);
-    expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(
-      `https://transfer.api.globusonline.org/v0.10/endpoint/${ENDPOINT}`,
-      {
-        headers: {},
-      },
-    );
+    const {
+      req: { url, method, headers },
+    } = await mirror(await endpoint.get(ENDPOINT));
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('delete', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(await endpoint.remove(ENDPOINT));
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
   });
 });

--- a/src/lib/services/transfer/__tests__/task.spec.ts
+++ b/src/lib/services/transfer/__tests__/task.spec.ts
@@ -1,0 +1,140 @@
+import { task } from '../index';
+import { createStorage } from '../../../core/storage';
+
+import { mirror } from '../../../../__mocks__/handlers';
+
+describe('task', () => {
+  beforeEach(() => {
+    createStorage('memory');
+  });
+
+  test('getAll', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(await task.getAll());
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('get', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(await task.get('example-task-id'));
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('update', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(
+      await task.update('example-task-id', {
+        payload: {
+          label: 'A new label.',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('cancel', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(await task.cancel('example-task-id'));
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('remove', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(await task.remove('example-task-id'));
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('getEventList', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(
+      await task.getEventList('example-task-id', {
+        query: {
+          filters: 'iserror:1',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('getSuccessfulTransfers', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(
+      await task.getSuccessfulTransfers('example-task-id', {
+        query: {
+          marker: '1',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('getSkippedErrors', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(
+      await task.getSkippedErrors('example-task-id', {
+        query: {
+          marker: '10',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('getPauseInfo', async () => {
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(await task.getPauseInfo('example-task-id'));
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+});

--- a/src/lib/services/transfer/config.ts
+++ b/src/lib/services/transfer/config.ts
@@ -1,6 +1,11 @@
 import type { Environment } from '../../core/global.js';
 
 export const ID = 'TRANSFER';
+
+export const SCOPES = {
+  ALL: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+};
+
 export const HOSTS: Partial<Record<Environment, string>> = {
   sandbox: 'transfer.sandbox.globuscs.info',
   production: 'transfer.api.globusonline.org',

--- a/src/lib/services/transfer/index.ts
+++ b/src/lib/services/transfer/index.ts
@@ -13,7 +13,9 @@ import { endpointSearch } from './service/endpoint-search.js';
  * @internal
  */
 export const CONFIG = TRANSFER;
+
 export { endpointSearch };
 export * as fileOperations from './service/file-operations.js';
 export * as taskSubmission from './service/task-submission.js';
 export * as endpoint from './service/endpoint.js';
+export * as task from './service/task.js';

--- a/src/lib/services/transfer/service/endpoint-search.ts
+++ b/src/lib/services/transfer/service/endpoint-search.ts
@@ -1,5 +1,5 @@
 import { serviceRequest } from '../../shared.js';
-import { ID } from '../config.js';
+import { ID, SCOPES } from '../config.js';
 
 import type { BaseServiceMethodOptions, SDKOptions } from '../../../services/types.js';
 
@@ -32,7 +32,7 @@ export const endpointSearch = function (
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/endpoint_search`,
     },
     serviceRequestOptions,

--- a/src/lib/services/transfer/service/endpoint.ts
+++ b/src/lib/services/transfer/service/endpoint.ts
@@ -46,5 +46,12 @@ export const remove = function (endpoint_xid, options?, sdkOptions?) {
   {
     query?: never;
     payload?: never;
-  }
+  },
+  JSONFetchResponse<{
+    DATA_TYPE: 'result';
+    code: 'Deleted';
+    message: string;
+    request_id: string;
+    resource: `/endpoint/${string}`;
+  }>
 >;

--- a/src/lib/services/transfer/service/endpoint.ts
+++ b/src/lib/services/transfer/service/endpoint.ts
@@ -1,4 +1,4 @@
-import { serviceRequest } from '../../shared.js';
+import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
 import { ID, SCOPES } from '../config.js';
 
@@ -24,4 +24,27 @@ export const get = function (endpoint_xid, options?, sdkOptions?) {
     payload?: never;
   },
   JSONFetchResponse<Globus.Transfer.EndpointDocument>
+>;
+
+/**
+ * Delete an endpoint by its UUID.
+ * @see https://docs.globus.org/api/transfer/endpoint/#delete_endpoint_by_id
+ */
+export const remove = function (endpoint_xid, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/endpoint/${endpoint_xid}`,
+      method: HTTP_METHODS.DELETE,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  }
 >;

--- a/src/lib/services/transfer/service/endpoint.ts
+++ b/src/lib/services/transfer/service/endpoint.ts
@@ -1,6 +1,6 @@
 import { serviceRequest } from '../../shared.js';
 
-import { ID } from '../config.js';
+import { ID, SCOPES } from '../config.js';
 
 import type { ServiceMethodDynamicSegments, JSONFetchResponse } from '../../../services/types.js';
 
@@ -11,7 +11,7 @@ export const get = function (endpoint_xid, options?, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/endpoint/${endpoint_xid}`,
     },
     options,

--- a/src/lib/services/transfer/service/file-operations.ts
+++ b/src/lib/services/transfer/service/file-operations.ts
@@ -1,7 +1,7 @@
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
 import { getHeadersForService } from '../shared.js';
-import { ID } from '../config.js';
+import { ID, SCOPES } from '../config.js';
 
 import type { Transfer } from '../types.js';
 import type { ServiceMethodDynamicSegments } from '../../types.js';
@@ -16,7 +16,7 @@ export const ls = function (endpoint_xid, options?, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/operation/endpoint/${endpoint_xid}/ls`,
     },
     options,
@@ -49,7 +49,7 @@ export const mkdir = function (endpoint_xid, options, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/operation/endpoint/${endpoint_xid}/mkdir`,
       method: HTTP_METHODS.POST,
     },
@@ -85,7 +85,7 @@ export const rename = function (endpoint_xid, options, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/operation/endpoint/${endpoint_xid}/rename`,
       method: HTTP_METHODS.POST,
     },
@@ -119,7 +119,7 @@ export const symlink = function (endpoint_xid, options, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/operation/endpoint/${endpoint_xid}/symlink`,
       method: HTTP_METHODS.POST,
     },

--- a/src/lib/services/transfer/service/task-submission.ts
+++ b/src/lib/services/transfer/service/task-submission.ts
@@ -1,7 +1,7 @@
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
 import { getHeadersForService } from '../shared.js';
-import { ID } from '../config.js';
+import { ID, SCOPES } from '../config.js';
 
 import type { Transfer } from '../types.js';
 import type { SDKOptions, ServiceMethod } from '../../types.js';
@@ -26,7 +26,7 @@ export const submitDelete = function (options, sdkOptions?: SDKOptions) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/delete`,
       method: HTTP_METHODS.POST,
     },
@@ -51,7 +51,7 @@ export const submitTransfer = function (options, sdkOptions?: SDKOptions) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/transfer`,
       method: HTTP_METHODS.POST,
     },
@@ -72,7 +72,7 @@ export const submissionId = function (options?, sdkOptions?) {
   return serviceRequest(
     {
       service: ID,
-      scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+      scope: SCOPES.ALL,
       path: `/v0.10/submission_id`,
     },
     options,

--- a/src/lib/services/transfer/service/task.ts
+++ b/src/lib/services/transfer/service/task.ts
@@ -1,0 +1,207 @@
+import { HTTP_METHODS, serviceRequest } from '../../shared.js';
+
+import { ID, SCOPES } from '../config.js';
+
+import type {
+  ServiceMethod,
+  ServiceMethodDynamicSegments,
+  JSONFetchResponse,
+} from '../../../services/types.js';
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#get_task_list
+ */
+export const getAll = function (options = {}, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task_list`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethod<{
+  query?: Record<string, string>;
+  headers?: Record<string, string>;
+  payload?: never;
+}>;
+
+/**
+ * Fetch an task by its UUID.
+ * @see https://docs.globus.org/api/transfer/task/#get_task_by_id
+ */
+export const get = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  },
+  JSONFetchResponse<Globus.Transfer.TaskDocument>
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#update_task_by_id
+ */
+export const update = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}`,
+      method: HTTP_METHODS.PUT,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload: Record<string, string>;
+  }
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#cancel_task_by_id
+ */
+export const cancel = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/cancel`,
+      method: HTTP_METHODS.POST,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  },
+  JSONFetchResponse<Globus.Transfer.TaskDocument>
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#remove_task_by_id
+ */
+export const remove = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/remove`,
+      method: HTTP_METHODS.POST,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  },
+  JSONFetchResponse<Globus.Transfer.TaskDocument>
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#get_event_list
+ */
+export const getEventList = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/event_list`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    payload?: never;
+  }
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#get_task_successful_transfers
+ */
+export const getSuccessfulTransfers = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/successful_transfers`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    payload?: never;
+  }
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#get_task_skipped_errors
+ */
+export const getSkippedErrors = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/skipped_errors`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    payload?: never;
+  }
+>;
+
+/**
+ * @see https://docs.globus.org/api/transfer/task/#get_task_pause_info
+ */
+export const getPauseInfo = function (task_id, options?, sdkOptions?) {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v0.10/task/${task_id}/pause_info`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    payload?: never;
+  }
+>;

--- a/src/lib/services/transfer/service/task.ts
+++ b/src/lib/services/transfer/service/task.ts
@@ -28,7 +28,7 @@ export const getAll = function (options = {}, sdkOptions?) {
 }>;
 
 /**
- * Fetch an task by its UUID.
+ * Fetch a task by its UUID.
  * @see https://docs.globus.org/api/transfer/task/#get_task_by_id
  */
 export const get = function (task_id, options?, sdkOptions?) {

--- a/src/lib/services/transfer/service/task.ts
+++ b/src/lib/services/transfer/service/task.ts
@@ -8,7 +8,10 @@ import type {
   JSONFetchResponse,
 } from '../../../services/types.js';
 
+import type { Transfer } from '../types.js';
+
 /**
+ * Get a list of tasks submitted by the current user.
  * @see https://docs.globus.org/api/transfer/task/#get_task_list
  */
 export const getAll = function (options = {}, sdkOptions?) {
@@ -21,11 +24,19 @@ export const getAll = function (options = {}, sdkOptions?) {
     options,
     sdkOptions,
   );
-} satisfies ServiceMethod<{
-  query?: Record<string, string>;
-  headers?: Record<string, string>;
-  payload?: never;
-}>;
+} satisfies ServiceMethod<
+  {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    payload?: never;
+  },
+  JSONFetchResponse<
+    {
+      DATA_TYPE: 'task_list';
+      DATA: Globus.Transfer.TaskDocument[];
+    } & Transfer['Paging']['Offset']['Response']
+  >
+>;
 
 /**
  * Fetch a task by its UUID.

--- a/src/lib/services/transfer/service/task.ts
+++ b/src/lib/services/transfer/service/task.ts
@@ -26,7 +26,7 @@ export const getAll = function (options = {}, sdkOptions?) {
   );
 } satisfies ServiceMethod<
   {
-    query?: Record<string, string>;
+    query?: Transfer['Paging']['Offset']['Query'] & Record<string, string>;
     headers?: Record<string, string>;
     payload?: never;
   },

--- a/src/lib/services/transfer/types.ts
+++ b/src/lib/services/transfer/types.ts
@@ -1,5 +1,69 @@
 export interface Transfer {
   /**
+   * Pagination used by the Transfer service.
+   *
+   * Each pagination definition contains a `Query` and `Response` type.
+   * - The `Query` type is used to define the query parameters used by the pagination method.
+   * - The `Response` type is used to define the response properties returned by the pagination method (usually as
+   * top-level keys in the response body).
+   *
+   * @see https://docs.globus.org/api/transfer/overview/#paging
+   */
+  Paging: {
+    /**
+     * @see https://docs.globus.org/api/transfer/overview/#offset_paging
+     */
+    Offset: {
+      Query: {
+        limit?: `${number}`;
+        offset?: `${number}`;
+      };
+      Response: {
+        limit: number;
+        offset: number;
+        has_next_page: `${boolean}`;
+      };
+    };
+    /**
+     * @see https://docs.globus.org/api/transfer/overview/#marker_paging
+     */
+    Marker: {
+      Query: {
+        marker?: string;
+      };
+      Response: {
+        next_marker: string | null;
+      };
+    };
+    /**
+     * @see https://docs.globus.org/api/transfer/overview/#last_key_paging
+     */
+    LastKey: {
+      Query: {
+        limit?: `${number}`;
+        last_key: string;
+      };
+      Response: {
+        has_next_page: `${boolean}`;
+        last_key: string | null;
+        limit: number;
+      };
+    };
+    /**
+     * @see https://docs.globus.org/api/transfer/overview/#next_token_paging
+     */
+    NextToken: {
+      Query: {
+        next_token?: string;
+        max_results?: `${number}`;
+      };
+      Response: {
+        next_token: string | null;
+      };
+    };
+  };
+
+  /**
    * @see https://docs.globus.org/api/transfer/file_operations/#list_directory_contents
    */
   DirectoryListingQuery: {


### PR DESCRIPTION
- feat(Transfer): adds support for `transfer.task.*` service methods, including: `getAll`, `get`, `update`, `cancel`, `remove`, `getEventList`, `getSuccessfulTransfers`, `getSkippedErrors`, and `getPauseInfo`
- feat(Transfer): adds support for `endpoint.remove`
- chore(Transfer): Adds Typescript types for `Transfer['Paging']`