### PR TITLE
fix(Auth): addresses an issue causing auth.oauth2 methods from making proper requests.

### DIFF
--- a/src/__mocks__/handlers.ts
+++ b/src/__mocks__/handlers.ts
@@ -18,6 +18,10 @@ export type MirroredRequest = {
      * JSON payload provided with the request, if any.
      */
     json?: unknown;
+    /**
+     * Form data provided with the request, if any.
+     */
+    formData?: object;
   };
 };
 
@@ -34,12 +38,21 @@ export const handlers = [
       headers[key] = value;
     });
 
+    const formData: Record<any, any> = {};
+    if (request.headers.get('content-type')?.includes('application/x-www-form-urlencoded')) {
+      const rawFormData = await request.formData();
+      rawFormData.forEach((value, key) => {
+        formData[key] = value;
+      });
+    }
+
     const mirroredRequest: MirroredRequest = {
       __msw: 'FALLBACK',
       req: {
         url: request.url,
         method: request.method,
         headers,
+        formData,
       },
     };
 

--- a/src/lib/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
+++ b/src/lib/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
@@ -2,59 +2,59 @@
 
 exports[`oauth2 introspect 1`] = `
 {
+  "formData": {
+    "include": "session_info,identity_set",
+    "token": "abc-def-ghi",
+  },
   "headers": {
     "accept": "*/*",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
-    "content-length": "61",
-    "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+    "content-length": "53",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
     "host": "auth.globus.org",
     "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
   },
-  "json": {
-    "include": "session_info,identity_set",
-    "token": "abc-def-ghi",
-  },
   "method": "POST",
-  "url": "https://auth.globus.org/v2/oauth/token/introspect",
+  "url": "https://auth.globus.org/v2/oauth2/token/introspect",
 }
 `;
 
 exports[`oauth2 revoke 1`] = `
 {
+  "formData": {
+    "token": "abc-def-ghi",
+  },
   "headers": {
     "accept": "*/*",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
-    "content-length": "23",
-    "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+    "content-length": "17",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
     "host": "auth.globus.org",
     "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
   },
-  "json": {
-    "token": "abc-def-ghi",
-  },
   "method": "POST",
-  "url": "https://auth.globus.org/v2/oauth/token/revoke",
+  "url": "https://auth.globus.org/v2/oauth2/token/revoke",
 }
 `;
 
 exports[`oauth2 validate 1`] = `
 {
+  "formData": {
+    "client_id": "my-client-id",
+    "token": "abc-def-ghi",
+  },
   "headers": {
     "accept": "*/*",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
-    "content-length": "50",
-    "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+    "content-length": "40",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
     "host": "auth.globus.org",
     "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
   },
-  "json": {
-    "client_id": "my-client-id",
-    "token": "abc-def-ghi",
-  },
   "method": "POST",
-  "url": "https://auth.globus.org/v2/oauth/token/validate",
+  "url": "https://auth.globus.org/v2/oauth2/token/validate",
 }
 `;

--- a/src/lib/services/auth/__tests__/oauth2.spec.ts
+++ b/src/lib/services/auth/__tests__/oauth2.spec.ts
@@ -8,6 +8,11 @@ describe('oauth2', () => {
   });
 
   test('introspect', async () => {
+    expect(() => {
+      // @ts-expect-error This intentionally does not have a payload to test the error case.
+      oauth2.token.introspect();
+    }).toThrow();
+
     const {
       req: { url, method, headers, formData },
     } = await mirror(
@@ -27,6 +32,11 @@ describe('oauth2', () => {
   });
 
   test('revoke', async () => {
+    expect(() => {
+      // @ts-expect-error This intentionally does not have a payload to test the error case.
+      oauth2.token.revoke();
+    }).toThrow();
+
     const {
       req: { url, method, headers, formData },
     } = await mirror(
@@ -45,6 +55,11 @@ describe('oauth2', () => {
   });
 
   test('validate', async () => {
+    expect(() => {
+      // @ts-expect-error This intentionally does not have a payload to test the error case.
+      oauth2.token.validate();
+    }).toThrow();
+
     const {
       req: { url, method, headers, formData },
     } = await mirror(

--- a/src/lib/services/auth/__tests__/oauth2.spec.ts
+++ b/src/lib/services/auth/__tests__/oauth2.spec.ts
@@ -9,7 +9,7 @@ describe('oauth2', () => {
 
   test('introspect', async () => {
     const {
-      req: { url, method, headers, json },
+      req: { url, method, headers, formData },
     } = await mirror(
       await oauth2.token.introspect({
         payload: {
@@ -22,13 +22,13 @@ describe('oauth2', () => {
       url,
       method,
       headers,
-      json,
+      formData,
     }).toMatchSnapshot();
   });
 
   test('revoke', async () => {
     const {
-      req: { url, method, headers, json },
+      req: { url, method, headers, formData },
     } = await mirror(
       await oauth2.token.revoke({
         payload: {
@@ -40,13 +40,13 @@ describe('oauth2', () => {
       url,
       method,
       headers,
-      json,
+      formData,
     }).toMatchSnapshot();
   });
 
   test('validate', async () => {
     const {
-      req: { url, method, headers, json },
+      req: { url, method, headers, formData },
     } = await mirror(
       await oauth2.token.validate({
         payload: {
@@ -55,12 +55,11 @@ describe('oauth2', () => {
         },
       }),
     );
-
     expect({
       url,
       method,
       headers,
-      json,
+      formData,
     }).toMatchSnapshot();
   });
 });

--- a/src/lib/services/auth/service/oauth2/token.ts
+++ b/src/lib/services/auth/service/oauth2/token.ts
@@ -28,11 +28,9 @@ function serialize(payload?: SupportedPayloads) {
  * Format and inject properties that are specific to the `/token` resources.
  */
 function injectServiceOptions(
-  options:
-    | (ServiceMethodOptions & {
-        payload?: SupportedPayloads;
-      })
-    | undefined,
+  options: ServiceMethodOptions & {
+    payload: SupportedPayloads;
+  },
 ): ServiceMethodOptions {
   return {
     ...options,
@@ -40,13 +38,13 @@ function injectServiceOptions(
      * The `token` service methods always expect a form-encoded body. We still allow
      * end-consumers to pass a raw body, but if `payload` is provided it is serialized.
      */
-    body: options?.body ?? options?.payload ? serialize(options?.payload) : undefined,
+    body: serialize(options.payload),
     headers: {
       ...(options?.headers || {}),
       /**
        * Force the `Content-Type` header to be `application/x-www-form-urlencoded` and `charset=UTF-8`.
        */
-      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     },
   };
 }
@@ -56,11 +54,14 @@ function injectServiceOptions(
  * @see https://docs.globus.org/api/auth/reference/#token-introspect
  */
 export const introspect = function (options, sdkOptions?) {
+  if (!options?.payload) {
+    throw new Error(`'payload' is required for introspect`);
+  }
   return serviceRequest(
     {
       service: ID,
       scope: undefined,
-      path: `/v2/oauth/token/introspect`,
+      path: `/v2/oauth2/token/introspect`,
       method: HTTP_METHODS.POST,
     },
     injectServiceOptions(options),
@@ -75,11 +76,14 @@ export const introspect = function (options, sdkOptions?) {
  * @see https://docs.globus.org/api/auth/reference/#token-revoke
  */
 export const revoke = function (options, sdkOptions?) {
+  if (!options?.payload) {
+    throw new Error(`'payload' is required for revoke`);
+  }
   return serviceRequest(
     {
       service: ID,
       scope: undefined,
-      path: `/v2/oauth/token/revoke`,
+      path: `/v2/oauth2/token/revoke`,
       method: HTTP_METHODS.POST,
     },
     injectServiceOptions(options),
@@ -94,11 +98,14 @@ export const revoke = function (options, sdkOptions?) {
  * @deprecated Rather than using `validate` to check if a token is valid, it is recommended to make a request to the resource server with the token and handle the error response.
  */
 export const validate = function (options, sdkOptions?) {
+  if (!options?.payload) {
+    throw new Error(`'payload' is required for validate`);
+  }
   return serviceRequest(
     {
       service: ID,
       scope: undefined,
-      path: `/v2/oauth/token/validate`,
+      path: `/v2/oauth2/token/validate`,
       method: HTTP_METHODS.POST,
     },
     injectServiceOptions(options),

--- a/src/lib/services/shared.ts
+++ b/src/lib/services/shared.ts
@@ -94,7 +94,10 @@ export function serviceRequest(
   /**
    * If a raw body was provided, use that. Otherwise, if a payload was provided, serialize it.
    */
-  const body = options?.body ?? options?.payload ? JSON.stringify(options.payload) : undefined;
+  let body = options?.body;
+  if (!body && options?.payload) {
+    body = JSON.stringify(options.payload);
+  }
 
   /**
    * If `Content-Type` header was not provided, and there is a body, we assume it is JSON.


### PR DESCRIPTION
- updates invalid resource path (oauth => oauth2)
- cleans up the raw `body` handling in the serviceRequest handler.
- adds `formData` testing to the mirror test utility