### PR TITLE
fix(Typescript, Transfer): fix improper DATA_TYPE type references for transfer.fileOperations.mkdir and transfer.fileOperations.rename

### DIFF
--- a/src/lib/services/transfer/types.ts
+++ b/src/lib/services/transfer/types.ts
@@ -77,10 +77,11 @@ export interface Transfer {
 
   Request: {
     Mkdir: {
+      DATA_TYPE: 'mkdir';
       path: string;
     };
     Rename: {
-      DATA_TYPE: 'mkdir';
+      DATA_TYPE: 'rename';
       old_path: string;
       new_path: string;
     };


### PR DESCRIPTION
This didn't seem to cause any compile time or runtime issues (since we allow arbitrary payloads), but updating for correctness.