### PR TITLE
fix(Authorization): attempting to access storage ("getStorage") before instantiation no longer throws an error, instead a default storage system is created.

### DIFF
--- a/src/lib/core/consent.ts
+++ b/src/lib/core/consent.ts
@@ -7,6 +7,9 @@ function isValidToken(check: unknown): check is Token {
   return Boolean(maybe.token_type && maybe.access_token);
 }
 
+/**
+ * Store a token in the active storage system.
+ */
 function store(token: ITokenResponse) {
   token.scope.split(' ').forEach((scope) => {
     getStorage().set(scope, token);
@@ -20,6 +23,11 @@ export function addTokenResponse(token: ITokenResponse | TokenResponse) {
   }
 }
 
+/**
+ * Obtain the token string for the given scope.
+ * @param scope The scope string that will be used to look up the token.
+ * @returns The token string for the given scope or null if no token is found.
+ */
 export function getTokenForScope(scope: string) {
   const token = getStorage().get(scope);
   if (!token || !isValidToken(token)) {

--- a/src/lib/core/storage/index.ts
+++ b/src/lib/core/storage/index.ts
@@ -10,7 +10,7 @@ export interface StorageSystem {
   clear(): void;
 }
 
-let storage: undefined | StorageSystem;
+let storage: StorageSystem | undefined;
 type StorageOptions =
   | 'localStorage'
   | 'memory'
@@ -33,18 +33,19 @@ export function createStorage(storageType: StorageOptions = 'memory'): StorageSy
     }
     storage = new Factory();
   }
-  return storage;
+  /**
+   * This cast is required based our use of resetting the storage system during testing.
+   * @see __reset
+   */
+  return storage as StorageSystem;
 }
 
 export default createStorage;
 
-export function getStorage() {
-  if (!storage) {
-    throw Error('You must create a storage system.');
-  }
-  return storage;
-}
-
+/**
+ * Returns the active storage system.
+ */
+export const getStorage = createStorage;
 /**
  * A private method for resetting the storage system. This is primarily used to reset
  * the storage system during testing.

--- a/src/lib/services/search/__tests__/__snapshots__/query.spec.ts.snap
+++ b/src/lib/services/search/__tests__/__snapshots__/query.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`search – query allows get without Authorization header 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://search.api.globus.org/v1/index/524de2f6-d1a6-4b49-9286-d8dccb4196ae/search?q=hello%2Bworld",
+}
+`;

--- a/src/lib/services/search/__tests__/query.spec.ts
+++ b/src/lib/services/search/__tests__/query.spec.ts
@@ -1,7 +1,7 @@
 import { createStorage } from '../../../core/storage';
 import { query } from '..';
 
-import type { MirroredRequest } from '../../../../__mocks__/handlers';
+import { MirroredRequest, mirror } from '../../../../__mocks__/handlers';
 
 describe('search – query', () => {
   test('get', async () => {
@@ -32,6 +32,34 @@ describe('search – query', () => {
       }
     `);
   });
+
+  /**
+   * @see https://github.com/globus/globus-sdk-javascript/issues/76
+   */
+  test('allows get without Authorization header', async () => {
+    expect(() => {
+      query.get('foobar', {
+        query: {
+          q: 'test',
+        },
+      });
+    }).not.toThrow();
+    const {
+      req: { url, method, headers },
+    } = await mirror(
+      await query.get('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {
+        query: {
+          q: 'hello+world',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
   test('post', async () => {
     createStorage('memory');
     const result = await query.post('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {


### PR DESCRIPTION
When calling a service method that specifies a scope, instead of throwing when a storage system hasn't been created, we create a default (in memory) token storage system.

Closes #76