### PR TITLE
fix(Typescript): allow non-string types for query properties

### DIFF
--- a/src/lib/services/search/service/query.ts
+++ b/src/lib/services/search/service/query.ts
@@ -27,8 +27,8 @@ export const get = function (index_id, options?, sdkOptions?) {
      */
     query?: {
       q: string;
-      offset?: `${number}`;
-      limit?: `${number}`;
+      offset?: `${number}` | number;
+      limit?: `${number}` | number;
       advanced?: 'true' | 'false';
       bypass_visible_to?: 'true' | 'false';
       result_format_version?: string;

--- a/src/lib/services/transfer/types.ts
+++ b/src/lib/services/transfer/types.ts
@@ -15,13 +15,13 @@ export interface Transfer {
      */
     Offset: {
       Query: {
-        limit?: `${number}`;
-        offset?: `${number}`;
+        limit?: `${number}` | number;
+        offset?: `${number}` | number;
       };
       Response: {
         limit: number;
         offset: number;
-        has_next_page: `${boolean}`;
+        has_next_page: `${boolean}` | boolean;
       };
     };
     /**
@@ -40,11 +40,11 @@ export interface Transfer {
      */
     LastKey: {
       Query: {
-        limit?: `${number}`;
+        limit?: `${number}` | number;
         last_key: string;
       };
       Response: {
-        has_next_page: `${boolean}`;
+        has_next_page: `${boolean}` | boolean;
         last_key: string | null;
         limit: number;
       };
@@ -55,7 +55,7 @@ export interface Transfer {
     NextToken: {
       Query: {
         next_token?: string;
-        max_results?: `${number}`;
+        max_results?: `${number}` | number;
       };
       Response: {
         next_token: string | null;
@@ -69,8 +69,8 @@ export interface Transfer {
   DirectoryListingQuery: {
     path?: string;
     show_hidden?: 'true' | 'false';
-    limit?: `${number}`;
-    offset?: `${number}`;
+    limit?: `${number}` | number;
+    offset?: `${number}` | number;
     orderby?: string;
     filter?: string;
   };


### PR DESCRIPTION
We now have
https://github.com/globus/globus-sdk-javascript/blob/main/src/lib/core/url.ts to handle building search strings. The query objects should accept the types as described in our service documentation.