### PR TITLE
fix(GCS): ensure all Globus Connect Server service resource methods are available on `getClient`

### DIFF
--- a/src/lib/services/globus-connect-server/__tests__/client.spec.ts
+++ b/src/lib/services/globus-connect-server/__tests__/client.spec.ts
@@ -1,29 +1,76 @@
+import { readdir } from 'node:fs/promises';
+
 import { createStorage } from '../../../core/storage';
 import { getClient } from '../client';
-
-import type { MirroredRequest } from '../../../../__mocks__/handlers';
+import { mirror } from '../../../../__mocks__/handlers';
 
 const GCS_CONFIGURATION = {
   host: 'https://fa5e.bd7c.data.globus.org',
   endpoint_id: 'ac9cb54b-fc48-4824-b801-1388baf0a909',
 };
 
-describe('gcs – client', () => {
+/**
+ * Basic string transformation to convert kebab-case to camelCase.
+ */
+function camelCase(str: string) {
+  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+}
+
+describe('gcs client', () => {
+  test('service methods', async () => {
+    /**
+     * Build an object of all of the expected service methods.
+     */
+    const expected: Record<string, string[]> = {};
+    const serviceFiles = await readdir(`${__dirname}/../service`);
+    await Promise.all(
+      serviceFiles.map(async (file) => {
+        const resource = await import(`${__dirname}/../service/${file}`);
+        const resourceName = camelCase(file.split('.')[0]);
+        /**
+         * The resource name is appended to the method name to better identify
+         * missing members in Jest assersions.
+         */
+        expected[resourceName] = Object.keys(resource).map((method) => `${resourceName}.${method}`);
+      }),
+    );
+    /**
+     * Create a client instance and compare the methods to the expected methods.
+     */
+    const client = getClient(GCS_CONFIGURATION);
+    Object.keys(expected).forEach((resource) => {
+      /**
+       * The service is a member of the client.
+       */
+      expect(client).toHaveProperty(resource);
+      /**
+       * The methods are members of the service.
+       */
+      const methods = Object.keys(client[resource as keyof typeof client]).map(
+        (method) => `${resource}.${method}`,
+      );
+      expect(methods).toEqual(expect.arrayContaining(expected[resource]));
+    });
+  });
+
   test('can be created WITHOUT storage', async () => {
     const client = getClient(GCS_CONFIGURATION);
 
-    const result = await client.endpoint.get(undefined, {
-      fetch: {
-        options: {
-          headers: {
-            Authorization: `Bearer SOME_TOKEN`,
+    const result = await mirror(
+      await client.endpoint.get(undefined, {
+        fetch: {
+          options: {
+            headers: {
+              Authorization: `Bearer SOME_TOKEN`,
+            },
           },
         },
-      },
-    });
+      }),
+    );
+
     const {
       req: { url, method, headers },
-    } = (await result.json()) as unknown as MirroredRequest;
+    } = result;
 
     expect({
       url,
@@ -44,27 +91,29 @@ describe('gcs – client', () => {
       }
     `);
 
-    const result2 = await client.collections.get(
-      'a-b-c-d',
-      {
-        query: {
-          include: ['private_policies'],
+    const result2 = await mirror(
+      await client.collections.get(
+        'a-b-c-d',
+        {
+          query: {
+            include: ['private_policies'],
+          },
         },
-      },
-      {
-        fetch: {
-          options: {
-            headers: {
-              Authorization: `Bearer SOME_OTHER_TOKEN`,
+        {
+          fetch: {
+            options: {
+              headers: {
+                Authorization: `Bearer SOME_OTHER_TOKEN`,
+              },
             },
           },
         },
-      },
+      ),
     );
 
     const {
       req: { url: url2, method: method2, headers: headers2 },
-    } = (await result2.json()) as unknown as MirroredRequest;
+    } = result2;
 
     expect({
       url: url2,
@@ -89,10 +138,9 @@ describe('gcs – client', () => {
   test('obtain client and call endpoint.get', async () => {
     createStorage('memory');
     const client = getClient(GCS_CONFIGURATION);
-    const result = await client.endpoint.get();
     const {
       req: { url, method, headers },
-    } = (await result.json()) as unknown as MirroredRequest;
+    } = await mirror(await client.endpoint.get());
     expect({
       url,
       method,
@@ -115,14 +163,15 @@ describe('gcs – client', () => {
   test('obtain client and call collections.get', async () => {
     createStorage('memory');
     const client = getClient(GCS_CONFIGURATION);
-    const result = await client.collections.get('5e70cb38-90b4-4939-b5b7-2f502363004bs', {
-      query: {
-        include: ['private_policies'],
-      },
-    });
     const {
       req: { url, method, headers },
-    } = (await result.json()) as unknown as MirroredRequest;
+    } = await mirror(
+      await client.collections.get('5e70cb38-90b4-4939-b5b7-2f502363004bs', {
+        query: {
+          include: ['private_policies'],
+        },
+      }),
+    );
     expect({
       url,
       method,

--- a/src/lib/services/globus-connect-server/client.ts
+++ b/src/lib/services/globus-connect-server/client.ts
@@ -52,6 +52,7 @@ export function getClient(configuration: GCSConfiguration) {
       get: bind(endpoint.get, configuration),
       update: bind(endpoint.update, configuration),
       patch: bind(endpoint.patch, configuration),
+      updateSubscriptionId: bind(endpoint.updateSubscriptionId, configuration),
     },
     versioning: {
       info: bind(versioning.info, configuration),
@@ -69,10 +70,18 @@ export function getClient(configuration: GCSConfiguration) {
     userCredentials: {
       get: bind(userCredentials.get, configuration),
       getAll: bind(userCredentials.getAll, configuration),
+      create: bind(userCredentials.create, configuration),
+      remove: bind(userCredentials.remove, configuration),
+      update: bind(userCredentials.update, configuration),
+      patch: bind(userCredentials.patch, configuration),
     },
     storageGateways: {
       get: bind(storageGateways.get, configuration),
       getAll: bind(storageGateways.getAll, configuration),
+      create: bind(storageGateways.create, configuration),
+      remove: bind(storageGateways.remove, configuration),
+      update: bind(storageGateways.update, configuration),
+      patch: bind(storageGateways.patch, configuration),
     },
     roles: {
       get: bind(roles.get, configuration),


### PR DESCRIPTION
- We added a few methods in a previous release that were not exposed via the `getClient` method.
- Adds a test to ensure service resources and methods are present on the `getClient` export.