### PR TITLE
fix(Typescript, Endpoint Manager, Transfer): updates the types returned by endpointManager.task.getSuccessfulTransfers and getSkippedErrors

### DIFF
--- a/src/lib/services/transfer/service/endpoint-manager/task.ts
+++ b/src/lib/services/transfer/service/endpoint-manager/task.ts
@@ -142,7 +142,7 @@ export const getSuccessfulTransfers = function (
   task_id,
   options?,
   sdkOptions?,
-): Promise<JSONFetchResponse<Globus.Transfer.SuccessfulTransfersDocument>> {
+): Promise<JSONFetchResponse<Globus.Transfer.SuccessfulTransfersListDocument>> {
   return serviceRequest(
     {
       service: ID,
@@ -167,7 +167,7 @@ export const getSkippedErrors = function (
   task_id,
   options?,
   sdkOptions?,
-): Promise<JSONFetchResponse<Globus.Transfer.SkippedErrorsDocument>> {
+): Promise<JSONFetchResponse<Globus.Transfer.SkippedErrorsListDocument>> {
   return serviceRequest(
     {
       service: ID,


### PR DESCRIPTION
These were previously using the single document type as the response, when it is actually a list response.