### PR TITLE
feat(Compute): adds initial support for Globus Compute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "js-pkce": "^1.2.1"
       },
       "devDependencies": {
-        "@globus/types": "0.0.6",
+        "@globus/types": "^0.0.7",
         "@tsconfig/recommended": "^1.0.5",
         "@types/jest": "29.5.12",
         "eslint": "^8.57.0",
@@ -36,7 +36,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@globus/types": "^0.0.6"
+        "@globus/types": "^0.0.7"
       },
       "peerDependenciesMeta": {
         "@globus/types": {
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@globus/types": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@globus/types/-/types-0.0.6.tgz",
-      "integrity": "sha512-DOQNPRlfioeULT3bcxwQtIbdrSGE4rWVVwRDbRSLNWZptyfWYaOssCymh86S+odFRzSxlm9R81ubSjMTtGF0aw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@globus/types/-/types-0.0.7.tgz",
+      "integrity": "sha512-SsAIX4FHqw8gO0p9GH+dOPBsCw2FmvuEJ+npFgdku1QKy5w/1fmqiMZGKz/X5TvHWQnG/KOaAen/q8SfFhD82Q==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@globus/types": "0.0.6",
+    "@globus/types": "^0.0.7",
     "@tsconfig/recommended": "^1.0.5",
     "@types/jest": "29.5.12",
     "eslint": "^8.57.0",
@@ -48,7 +48,7 @@
     "js-pkce": "^1.2.1"
   },
   "peerDependencies": {
-    "@globus/types": "^0.0.6"
+    "@globus/types": "^0.0.7"
   },
   "peerDependenciesMeta": {
     "@globus/types": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,3 +65,4 @@ export * as groups from './lib/services/groups/index.js';
 export * as flows from './lib/services/flows/index.js';
 export * as gcs from './lib/services/globus-connect-server/index.js';
 export * as timer from './lib/services/timer/index.js';
+export * as compute from './lib/services/compute/index.js';

--- a/src/lib/core/global.ts
+++ b/src/lib/core/global.ts
@@ -4,6 +4,7 @@ import * as FLOWS from '../services/flows/config.js';
 import * as GROUPS from '../services/groups/config.js';
 import * as SEARCH from '../services/search/config.js';
 import * as TIMER from '../services/timer/config.js';
+import * as COMPUTE from '../services/compute/config.js';
 
 import { EnvironmentConfigurationError } from './errors.js';
 import { SDKOptions } from '../services/types.js';
@@ -59,6 +60,7 @@ export const SERVICES = {
   [GROUPS.ID]: GROUPS.ID,
   [SEARCH.ID]: SEARCH.ID,
   [TIMER.ID]: TIMER.ID,
+  [COMPUTE.ID]: COMPUTE.ID,
 };
 
 export type Service = keyof typeof SERVICES;
@@ -70,6 +72,7 @@ export const SERVICE_HOSTS: Record<Service, Partial<Record<Environment, string>>
   [GROUPS.ID]: GROUPS.HOSTS,
   [SEARCH.ID]: SEARCH.HOSTS,
   [TIMER.ID]: TIMER.HOSTS,
+  [COMPUTE.ID]: COMPUTE.HOSTS,
 };
 
 /**

--- a/src/lib/services/compute/__tests__/__snapshots__/compute.spec.ts.snap
+++ b/src/lib/services/compute/__tests__/__snapshots__/compute.spec.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compute.endpoints get 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "compute.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://compute.api.globus.org/v2/endpoints/some-uuid",
+}
+`;
+
+exports[`compute.endpoints getAll 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "compute.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://compute.api.globus.org/v2/endpoints",
+}
+`;

--- a/src/lib/services/compute/__tests__/compute.spec.ts
+++ b/src/lib/services/compute/__tests__/compute.spec.ts
@@ -1,0 +1,32 @@
+import { endpoints } from '../index';
+import { createStorage } from '../../../core/storage';
+
+import { mirror } from '../../../../__mocks__/handlers';
+
+describe('compute.endpoints', () => {
+  beforeEach(() => {
+    createStorage('memory');
+  });
+
+  test('getAll', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(await endpoints.getAll());
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('get', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(await endpoints.get('some-uuid'));
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+});

--- a/src/lib/services/compute/config.ts
+++ b/src/lib/services/compute/config.ts
@@ -1,0 +1,15 @@
+import type { Environment } from '../../core/global.js';
+
+export const ID = 'COMPUTE';
+export const HOSTS: Partial<Record<Environment, string>> = {
+  sandbox: 'compute.api.sandbox.globuscs.info',
+  production: 'compute.api.globus.org',
+  staging: 'compute.api.staging.globuscs.info',
+  integration: 'compute.api.integration.globuscs.info',
+  test: 'compute.api.test.globuscs.info',
+  preview: 'compute.api.preview.globus.org',
+};
+
+export const SCOPES = {
+  ALL: 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all',
+};

--- a/src/lib/services/compute/index.ts
+++ b/src/lib/services/compute/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @description A wrapper around the Globus Compute service.
+ * @group Service
+ * @see [Globus Compute API Documentation](https://api2.funcx.org/redoc)
+ * @module
+ */
+import * as COMPUTE from './config.js';
+
+/**
+ * @private
+ * @internal
+ */
+export const CONFIG = COMPUTE;
+
+export * as endpoints from './service/endpoints.js';

--- a/src/lib/services/compute/service/endpoints.ts
+++ b/src/lib/services/compute/service/endpoints.ts
@@ -1,0 +1,58 @@
+import type { operations } from '@globus/types/compute';
+import { HTTP_METHODS, serviceRequest } from '../../shared.js';
+import { ID, SCOPES } from '../config.js';
+
+import type {
+  ServiceMethod,
+  ServiceMethodDynamicSegments,
+  JSONFetchResponse,
+} from '../../types.js';
+
+export const getAll = function (
+  options?,
+  sdkOptions?,
+): Promise<
+  JSONFetchResponse<
+    operations['get_endpoints_v2_endpoints_get']['responses']['200']['content']['application/json']
+  >
+> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: '/v2/endpoints',
+      method: HTTP_METHODS.GET,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethod<{
+  query: operations['get_endpoints_v2_endpoints_get']['parameters']['query'];
+}>;
+
+export const get = function (
+  endpoint_uuid,
+  options?,
+  sdkOptions?,
+): Promise<
+  JSONFetchResponse<
+    operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['responses']['200']['content']['application/json']
+  >
+> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v2/endpoints/${endpoint_uuid}`,
+      method: HTTP_METHODS.GET,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['parameters']['path']['endpoint_uuid'],
+  {
+    query?: never;
+    payload?: never;
+  }
+>;


### PR DESCRIPTION
- Adds `compute.endpoints.get` and `compute.endpoints.getAll`
- Bumps @globus/types requirement to latest (0.0.7)