### PR TITLE
fix: disable importHelpers to avoid peerDependency of tslib for consumers

### DIFF
--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "sourceMap": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "target": "es6",
     "module": "es2022",
     "lib": ["es2022", "dom"],


### PR DESCRIPTION
- For those looking to reduce bundle size (or using TS), we recommend using the ESM build instead of the CJS build.