### PR TITLE
docs: adds additional documentation to Authorization and Errors

### DIFF
--- a/src/lib/core/authorization/index.ts
+++ b/src/lib/core/authorization/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @module Authorization
+ * @description Provides modules for interacting with Globus-related authorization contexts in your application.
+ * @example
+ * import { authorization } from "globus/sdk";
+ * const manager = authorization.create(...);
+ */
 import {
   AuthorizationManager,
   type AuthorizationManagerConfiguration,
@@ -6,14 +13,14 @@ import {
 import * as tokens from './tokens.js';
 
 export * as tokens from './tokens.js';
+
 /**
  * @deprecated This will be removed in a future release. Use an instance of the AuthorizationManager instead.
  */
 export const { getTokenForScope } = tokens;
 
 /**
- * Create an instance of the AuthorizationManager.
- * @experimental
+ * Create an instance of the {@link AuthorizationManager}.
  */
 export function create(configuration: AuthorizationManagerConfiguration) {
   return new AuthorizationManager(configuration);

--- a/src/lib/core/errors.ts
+++ b/src/lib/core/errors.ts
@@ -1,3 +1,10 @@
+/**
+ * @module Errors
+ * @example
+ * import { errors } from "globus/sdk";
+ * if (errors.isConsentRequiredError(...)) { ... }
+ */
+
 export class EnvironmentConfigurationError extends Error {
   override name = 'EnvironmentConfigurationError';
 


### PR DESCRIPTION
The `basic` example README was also updated in a previous commit ([d111aae](https://github.com/globus/globus-sdk-javascript/commit/d111aaed2956275e160aad8b9ff5fb8e4b6dd4a0)).

closes #172 