### PR TITLE
fix(Transfer, Typescript): updates return type of `transfer.endpointManager.getPauseInfo` (PauseInfoLimitedDocument)

### DIFF
--- a/src/lib/services/transfer/service/endpoint-manager/task.ts
+++ b/src/lib/services/transfer/service/endpoint-manager/task.ts
@@ -236,7 +236,7 @@ export const getPauseInfo = function (
   task_id,
   options?,
   sdkOptions?,
-): Promise<JSONFetchResponse<Globus.Transfer.PauseRuleLimitedDocument[]>> {
+): Promise<JSONFetchResponse<Globus.Transfer.PauseInfoLimitedDocument>> {
   return serviceRequest(
     {
       service: ID,

--- a/src/lib/services/transfer/service/endpoint-manager/task.ts
+++ b/src/lib/services/transfer/service/endpoint-manager/task.ts
@@ -236,7 +236,7 @@ export const getPauseInfo = function (
   task_id,
   options?,
   sdkOptions?,
-): Promise<JSONFetchResponse<Globus.Transfer.AdminPauseDocumentResponse>> {
+): Promise<JSONFetchResponse<Globus.Transfer.PauseRuleLimitedDocument[]>> {
   return serviceRequest(
     {
       service: ID,


### PR DESCRIPTION
https://docs.globus.org/api/transfer/advanced_collection_management/#get_task_pause_info