### PR TITLE
fix(Authorization): improves AuthorizationRequirementsError type and related utilities.

### DIFF
--- a/src/lib/core/__tests__/errors.spec.ts
+++ b/src/lib/core/__tests__/errors.spec.ts
@@ -2,6 +2,7 @@ import {
   isErrorWellFormed,
   isConsentRequiredError,
   isAuthorizationRequirementsError,
+  toAuthorizationQueryParams,
 } from '../errors';
 
 export const TRANSFER_GENERIC_ERROR = {
@@ -82,5 +83,32 @@ describe('isAuthorizationRequirementsError', () => {
 
   it('should return false for a missing authorization_parameters property', () => {
     expect(isAuthorizationRequirementsError({ code: 'test' })).toBe(false);
+  });
+});
+
+describe('toAuthorizationQueryParams', () => {
+  it('reformat as expected', () => {
+    expect(toAuthorizationQueryParams(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR)).toEqual({
+      session_message: 'Session reauthentication required (Globus Transfer)',
+      session_required_identities: '',
+      session_required_mfa: 'false',
+      session_required_single_domain: 'globus.org',
+    });
+  });
+  it('handles empty', () => {
+    expect(
+      toAuthorizationQueryParams({
+        authorization_parameters: {},
+      }),
+    ).toEqual({});
+  });
+  it('drops known unsupported properties', () => {
+    expect(
+      toAuthorizationQueryParams({
+        authorization_parameters: {
+          required_scopes: ['foobar'],
+        },
+      }),
+    ).toEqual({});
   });
 });

--- a/src/lib/core/authorization/AuthorizationManager.ts
+++ b/src/lib/core/authorization/AuthorizationManager.ts
@@ -26,6 +26,7 @@ import {
   isAuthorizationRequirementsError,
   AuthorizationRequirementsError,
   ConsentRequiredError,
+  toAuthorizationQueryParams,
 } from '../errors.js';
 
 import type {
@@ -427,13 +428,8 @@ export class AuthorizationManager {
   ) {
     this.#transport = this.#buildTransport({
       params: {
-        session_message: response.authorization_parameters.session_message,
-        session_required_identities:
-          response.authorization_parameters.session_required_identities.join(','),
-        session_required_mfa: response.authorization_parameters.session_required_mfa,
-        session_required_single_domain:
-          response.authorization_parameters.session_required_single_domain.join(','),
         prompt: 'login',
+        ...toAuthorizationQueryParams(response),
         ...options?.additionalParams,
       },
     });

--- a/src/lib/services/auth/index.ts
+++ b/src/lib/services/auth/index.ts
@@ -16,6 +16,20 @@ import type { Token, TokenWithRefresh, TokenResponse } from './types.js';
  */
 export const CONFIG = AUTH;
 
+/**
+ * Query parameters that can be passed to the authorization endpoint.
+ * @see https://docs.globus.org/api/auth/reference/#authorization_code_grant_preferred
+ * @see https://docs.globus.org/api/auth/sessions/#client-initiated-authns
+ */
+export type AuthorizationQueryParameters = {
+  prompt?: string;
+  session_message?: string;
+  session_required_identities?: string;
+  session_required_single_domain?: string;
+  session_required_mfa?: 'true' | 'false';
+  session_required_policies?: string;
+};
+
 export function getAuthorizationEndpoint() {
   return build(AUTH.ID, '/v2/oauth2/authorize');
 }


### PR DESCRIPTION
- adds `prompt` and `required_scopes` to `AuthorizationRequirementsError`
- all members of `AuthorizationRequirementsError` are optional.
- adds `AuthorizationQueryParameters` type for the Globus Auth query parameters... which are different!
- adds `sdk.errors.toAuthoriztionQueryParams` utility.
- updates `AuthorizationManager` to use the new utility.