### PR TITLE
fix(errors, Typescript): adds `session_required_policies` to `AuthorizatonRequirementsError` type

### DIFF
--- a/src/lib/core/errors.ts
+++ b/src/lib/core/errors.ts
@@ -52,6 +52,7 @@ export type AuthorizationRequirementsError = {
     session_required_identities?: string[];
     session_required_mfa?: boolean;
     session_required_single_domain?: string[];
+    session_required_policies?: string[];
     prompt?: string;
     required_scopes?: string[];
   };


### PR DESCRIPTION
Missed this addition in #206 (only added to the query parameter type).