### PR TITLE
fix(Errors): updates isAuthorizationRequirementsError method to not require "message" or "code"

### DIFF
--- a/src/__mocks__/errors/authorization_parameters.ts
+++ b/src/__mocks__/errors/authorization_parameters.ts
@@ -1,0 +1,59 @@
+/**
+ * Service responses that are expected to pass `isAuthorizationRequirementsError` checks.
+ */
+export const FLOWS_AUTHORIZATION_REQUIREMENTS_ERROR = {
+  code: 'ConsentRequired',
+  state_name: 'RunTransfer',
+  description:
+    "Flow run requires user intervention to proceed. For state 'RunTransfer': Missing required data_access consent",
+  required_scope:
+    'https://auth.globus.org/scopes/28e781ba-dacb-4105-a411-fffc4fb8de62/flow_28e781ba_dacb_4105_a411_fffc4fb8de62_user[*https://auth.globus.org/scopes/actions.globus.org/transfer/transfer[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/543aade1-db97-4a4b-9bdf-0b58e78dfa69/data_access]]]',
+  action_statuses: [
+    {
+      label: null,
+      status: 'INACTIVE',
+      details: {
+        code: 'ConsentRequired',
+        description: 'Missing required data_access consent',
+        required_scope:
+          'https://auth.globus.org/scopes/actions.globus.org/transfer/transfer[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/543aade1-db97-4a4b-9bdf-0b58e78dfa69/data_access]]',
+        authorization_parameters: {
+          required_scopes: [
+            'https://auth.globus.org/scopes/actions.globus.org/transfer/transfer[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/543aade1-db97-4a4b-9bdf-0b58e78dfa69/data_access]]',
+          ],
+          session_message: 'Missing required data_access consent',
+        },
+      },
+      action_id: '5Fh4TTf0ribz',
+      manage_by: [],
+      creator_id: 'urn:globus:auth:identity:1d611a6d-9a22-4de5-b855-ba793df9b309',
+      monitor_by: [],
+      start_time: '2024-07-09T16:57:01.012765+00:00',
+      state_name: 'RunTransfer',
+      release_after: 'P30D',
+      display_status: 'INACTIVE',
+      completion_time: '2024-07-09T16:57:01.012794+00:00',
+    },
+  ],
+  authorization_parameters: {
+    required_scopes: [
+      'https://auth.globus.org/scopes/28e781ba-dacb-4105-a411-fffc4fb8de62/flow_28e781ba_dacb_4105_a411_fffc4fb8de62_user[*https://auth.globus.org/scopes/actions.globus.org/transfer/transfer[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/543aade1-db97-4a4b-9bdf-0b58e78dfa69/data_access]]]',
+    ],
+    session_message:
+      "Flow run requires user intervention to proceed. For state 'RunTransfer': Missing required data_access consent",
+  },
+};
+
+export const TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR = {
+  authorization_parameters: {
+    session_message: 'Session reauthentication required (Globus Transfer)',
+    session_required_identities: [],
+    session_required_mfa: false,
+    session_required_single_domain: ['globus.org'],
+  },
+  code: 'ExternalError.DirListingFailed.LoginFailed',
+  message:
+    'Command Failed: Error (login)\nEndpoint: Globus Staff GCSv5.4 Demo POSIX HA (eed63c24-36cb-4f29-a47f-91d94a65fef8)\nServer: 35.89.91.21:443\nMessage: Login Failed\n---\nDetails: 530-Login incorrect. : GlobusError: v=1 c=LOGIN_DENIED\\r\\n530-GridFTP-Message: None of your identities are from domains allowed by resource policies\\r\\n530-GridFTP-JSON-Result: {"DATA_TYPE": "result#1.0.0", "code": "permission_denied", "detail": {"DATA_TYPE": "not_from_allowed_domain#1.0.0", "allowed_domains": ["globus.org"]}, "has_next_page": false, "http_response_code": 403, "message": "None of your identities are from domains allowed by resource policies"}\\r\\n530 End.\\r\\n\n',
+  request_id: 'rvWu7tCfa',
+  resource: '/operation/endpoint/eed63c24-36cb-4f29-a47f-91d94a65fef8/ls',
+};

--- a/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
+++ b/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
@@ -6,11 +6,8 @@ import '../../../../__mocks__/sessionStorage';
 import '../../../../__mocks__/window-location';
 import { AuthorizationManager } from '../../authorization/AuthorizationManager';
 import { Event } from '../../authorization/Event';
-import {
-  TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR,
-  TRANSFER_CONSENT_REQUIRED_ERROR,
-  TRANSFER_GENERIC_ERROR,
-} from '../errors.spec';
+import { TRANSFER_CONSENT_REQUIRED_ERROR, TRANSFER_GENERIC_ERROR } from '../errors.spec';
+import { TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR } from '../../../../__mocks__/errors/authorization_parameters';
 
 describe('AuthorizationManager', () => {
   beforeEach(() => {

--- a/src/lib/core/__tests__/errors.spec.ts
+++ b/src/lib/core/__tests__/errors.spec.ts
@@ -1,4 +1,9 @@
 import {
+  FLOWS_AUTHORIZATION_REQUIREMENTS_ERROR,
+  TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR,
+} from '../../../__mocks__/errors/authorization_parameters';
+
+import {
   isErrorWellFormed,
   isConsentRequiredError,
   isAuthorizationRequirementsError,
@@ -62,20 +67,6 @@ describe('isConsentRequiredError', () => {
   });
 });
 
-export const TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR = {
-  authorization_parameters: {
-    session_message: 'Session reauthentication required (Globus Transfer)',
-    session_required_identities: [],
-    session_required_mfa: false,
-    session_required_single_domain: ['globus.org'],
-  },
-  code: 'ExternalError.DirListingFailed.LoginFailed',
-  message:
-    'Command Failed: Error (login)\nEndpoint: Globus Staff GCSv5.4 Demo POSIX HA (eed63c24-36cb-4f29-a47f-91d94a65fef8)\nServer: 35.89.91.21:443\nMessage: Login Failed\n---\nDetails: 530-Login incorrect. : GlobusError: v=1 c=LOGIN_DENIED\\r\\n530-GridFTP-Message: None of your identities are from domains allowed by resource policies\\r\\n530-GridFTP-JSON-Result: {"DATA_TYPE": "result#1.0.0", "code": "permission_denied", "detail": {"DATA_TYPE": "not_from_allowed_domain#1.0.0", "allowed_domains": ["globus.org"]}, "has_next_page": false, "http_response_code": 403, "message": "None of your identities are from domains allowed by resource policies"}\\r\\n530 End.\\r\\n\n',
-  request_id: 'rvWu7tCfa',
-  resource: '/operation/endpoint/eed63c24-36cb-4f29-a47f-91d94a65fef8/ls',
-};
-
 describe('isAuthorizationRequirementsError', () => {
   it('should return true for an authorization requirements error', () => {
     expect(isAuthorizationRequirementsError(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR)).toBe(true);
@@ -83,6 +74,12 @@ describe('isAuthorizationRequirementsError', () => {
 
   it('should return false for a missing authorization_parameters property', () => {
     expect(isAuthorizationRequirementsError({ code: 'test' })).toBe(false);
+  });
+  /**
+   * Service Errors
+   */
+  it('supports Globus Flows', () => {
+    expect(isAuthorizationRequirementsError(FLOWS_AUTHORIZATION_REQUIREMENTS_ERROR)).toBe(true);
   });
 });
 

--- a/src/lib/core/errors.ts
+++ b/src/lib/core/errors.ts
@@ -56,6 +56,12 @@ export type AuthorizationRequirementsError = {
     prompt?: string;
     required_scopes?: string[];
   };
+  /**
+   * @todo At the moment, most Globus services do not guarentee a `code` property for this error type.
+   * Once it becomes more common, this type (and the `isAuthorizationRequirementsError` function) should be updated.
+   * @see https://globus-sdk-python.readthedocs.io/en/stable/experimental/auth_requirements_errors.html
+   */
+  // code: string;
   [key: string]: unknown;
 };
 /**
@@ -88,11 +94,16 @@ export function toAuthorizationQueryParams(
   }, {});
 }
 
+/**
+ * Check if an object is an `AuthorizationRequirementsError`.
+ * @see {@link AuthorizationRequirementsError}
+ */
 export function isAuthorizationRequirementsError(
   test: unknown,
 ): test is AuthorizationRequirementsError {
   return (
-    isErrorWellFormed(test) &&
+    typeof test === 'object' &&
+    test !== null &&
     'authorization_parameters' in test &&
     typeof test.authorization_parameters === 'object' &&
     test.authorization_parameters !== null


### PR DESCRIPTION
- This better reflects the current state of `authorization_parameters` returned by services.
- Eventually, this will be updated to require/introspect `code`, but until most services are using the SDK to generate these errors the presence of `code` in the response will likely be hit or miss.