### PR TITLE
fix: `GLOBUS_SDK_ENVIRONMENT` environment variable will now take precedence over `GLOBUS_SDK_OPTIONS`

### DIFF
--- a/src/lib/core/__tests__/global.spec.ts
+++ b/src/lib/core/__tests__/global.spec.ts
@@ -35,7 +35,7 @@ describe('getEnvironment', () => {
     }).toThrow(EnvironmentConfigurationError);
   });
 
-  it('should take precedence over SDKOptions object', () => {
+  it('uses GLOBUS_SDK_ENVIRONMENT over GLOBUS_SDK_OPTIONS for sourcing environment', () => {
     process.env['GLOBUS_SDK_OPTIONS'] = JSON.stringify({
       environment: ENVIRONMENTS.PREVIEW,
     });

--- a/src/lib/core/__tests__/global.spec.ts
+++ b/src/lib/core/__tests__/global.spec.ts
@@ -43,7 +43,7 @@ describe('getEnvironment', () => {
     expect(getEnvironment()).toEqual(ENVIRONMENTS.SANDBOX);
   });
 
-  it('should be sourced from SDKOptions object when GLOBUS_SDK_ENVIRONMENT var is not set', () => {
+  it('should be sourced from GLOBUS_SDK_OPTIONS when GLOBUS_SDK_ENVIRONMENT is not set', () => {
     process.env['GLOBUS_SDK_OPTIONS'] = JSON.stringify({
       environment: ENVIRONMENTS.PREVIEW,
     });

--- a/src/lib/core/__tests__/global.spec.ts
+++ b/src/lib/core/__tests__/global.spec.ts
@@ -34,6 +34,22 @@ describe('getEnvironment', () => {
       getEnvironment();
     }).toThrow(EnvironmentConfigurationError);
   });
+
+  it('should take precedence over SDKOptions object', () => {
+    process.env['GLOBUS_SDK_OPTIONS'] = JSON.stringify({
+      environment: ENVIRONMENTS.PREVIEW,
+    });
+    process.env['GLOBUS_SDK_ENVIRONMENT'] = ENVIRONMENTS.SANDBOX;
+    expect(getEnvironment()).toEqual(ENVIRONMENTS.SANDBOX);
+  });
+
+  it('should be sourced from SDKOptions object when GLOBUS_SDK_ENVIRONMENT var is not set', () => {
+    process.env['GLOBUS_SDK_OPTIONS'] = JSON.stringify({
+      environment: ENVIRONMENTS.PREVIEW,
+    });
+    delete process.env['GLOBUS_SDK_ENVIRONMENT'];
+    expect(getEnvironment()).toEqual(ENVIRONMENTS.PREVIEW);
+  });
 });
 
 describe('getVerifySSL', () => {

--- a/src/lib/core/global.ts
+++ b/src/lib/core/global.ts
@@ -45,14 +45,6 @@ export const ENVIRONMENTS = {
 
 export type Environment = (typeof ENVIRONMENTS)[keyof typeof ENVIRONMENTS];
 
-export function getEnvironment(): Environment {
-  const environment = env<Environment>('GLOBUS_SDK_ENVIRONMENT', ENVIRONMENTS.PRODUCTION);
-  if (!environment || !Object.values(ENVIRONMENTS).includes(environment)) {
-    throw new EnvironmentConfigurationError('GLOBUS_SDK_ENVIRONMENT', environment);
-  }
-  return environment;
-}
-
 export const SERVICES = {
   [AUTH.ID]: AUTH.ID,
   [TRANSFER.ID]: TRANSFER.ID,
@@ -101,6 +93,18 @@ export function getSDKOptions(options?: SDKOptions) {
       },
     },
   };
+}
+
+export function getEnvironment(): Environment {
+  const globalOptions = getSDKOptions();
+  const environment = env<Environment>(
+    'GLOBUS_SDK_ENVIRONMENT',
+    globalOptions?.environment ?? ENVIRONMENTS.PRODUCTION,
+  );
+  if (!environment || !Object.values(ENVIRONMENTS).includes(environment)) {
+    throw new EnvironmentConfigurationError('GLOBUS_SDK_ENVIRONMENT', environment);
+  }
+  return environment;
 }
 
 /**

--- a/src/lib/core/global.ts
+++ b/src/lib/core/global.ts
@@ -8,6 +8,7 @@ import * as COMPUTE from '../services/compute/config.js';
 
 import { EnvironmentConfigurationError } from './errors.js';
 import { SDKOptions } from '../services/types.js';
+import { log } from './logger.js';
 
 function getRuntime() {
   return typeof window !== 'undefined' ? window : process;
@@ -101,6 +102,12 @@ export function getEnvironment(): Environment {
     'GLOBUS_SDK_ENVIRONMENT',
     globalOptions?.environment ?? ENVIRONMENTS.PRODUCTION,
   );
+  if (globalOptions?.environment && environment !== globalOptions.environment) {
+    log(
+      'debug',
+      'GLOBUS_SDK_ENVIRONMENT and GLOBUS_SDK_OPTIONS.environment are set to different values. GLOBUS_SDK_ENVIRONMENT will take precedence',
+    );
+  }
   if (!environment || !Object.values(ENVIRONMENTS).includes(environment)) {
     throw new EnvironmentConfigurationError('GLOBUS_SDK_ENVIRONMENT', environment);
   }
@@ -119,7 +126,8 @@ export function getEnvironment(): Environment {
 export function getVerifySSL(): boolean {
   const verifySSLTemp = env<string>('GLOBUS_SDK_VERIFY_SSL', 'true').toLowerCase();
   if (['n', 'no', 'f', 'false', 'off', '0'].includes(verifySSLTemp)) {
-    console.warn(
+    log(
+      'warn',
       'Setting GLOBUS_SDK_VERIFY_SSL to false is disallowed in the Globus JavaScript SDK. It will always true in this context',
     );
   }


### PR DESCRIPTION
- precedence should have the ENV var above config object