### PR TITLE
fix(Authorization): Automatic silent refresh of tokens (on instantiation) is now controlled via configuration (disabled by default).

### DIFF
--- a/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
+++ b/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
@@ -54,12 +54,13 @@ describe('AuthorizationManager', () => {
     }).toThrow();
   });
 
-  it('should startSilentRefresh on creation', () => {
+  it('should startSilentRefresh on creation, when configured', () => {
     const spy = jest.spyOn(AuthorizationManager.prototype, 'startSilentRefresh');
     const instance = new AuthorizationManager({
       client: 'client_id',
       redirect: 'https://redirect_uri',
       scopes: 'foobar baz',
+      automaticSilentRefresh: true,
     });
     expect(instance).toBeDefined();
     expect(spy).toHaveBeenCalledTimes(1);
@@ -123,9 +124,10 @@ describe('AuthorizationManager', () => {
       redirect: 'https://redirect_uri',
       scopes: 'profile email openid',
       useRefreshTokens: true,
+      automaticSilentRefresh: true,
     });
 
-    expect(instance.authenticated).toBe(true);
+    expect(instance.authenticated).toBe(false);
     expect(instance.tokens.auth?.access_token).toBe('access-token');
     expect(instance.tokens.transfer?.access_token).toBe('access-token');
 
@@ -133,9 +135,7 @@ describe('AuthorizationManager', () => {
     /**
      * This effectively waits for the next tick to allow the refresh promise to resolve.
      */
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await instance.waitForSilentRefresh;
     expect(instance.tokens.auth?.access_token).toBe('new-token');
     expect(instance.tokens.auth?.refresh_token).toBe('new-refresh-token');
     /**


### PR DESCRIPTION
- The `AutorizationManager` will now only automatically attempt to refresh tokens on creation when configured with `automaticSilentRefresh: true`.
- The `startSilentRefresh` internal method has also been updated dispatch an `authenticated` event after processing all refresh tokens.
- A new property `manager.waitForSilentRefresh` exposes a Promise depicting the state of _all_ inflight refresh requests.

All of these changes are in service of better application state control on instance creation. Without these changes, it was fairly common for any application listening to changes to tokens to effectively bootstrap twice - once for the token in storage and again when the tokens were refreshed.