### PR TITLE
feat: adds Transfer utilities related to `FileDocument`

### DIFF
--- a/src/lib/services/transfer/__tests__/utils.spec.ts
+++ b/src/lib/services/transfer/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { readableBytes, isDirectory, isFileDocument } from '../utils';
+import { readableBytes, isDirectory, isFileDocument, getDomainFromEndpoint } from '../utils';
 
 describe('readableBytes', () => {
   it('should return the correct readable string for bytes', () => {
@@ -51,5 +51,33 @@ describe('isFileDocument', () => {
     expect(isFileDocument(FILE)).toBe(true);
     expect(isFileDocument(DIR)).toBe(true);
     expect(isFileDocument(INVALID_SYMLINK)).toBe(true);
+  });
+});
+
+describe('getDomainFromEndpoint', () => {
+  it('should return the domain from a valid endpoint', () => {
+    /**
+     * Custom Domain
+     */
+    expect(
+      getDomainFromEndpoint({
+        tlsftp_server: 'tlsftp://m-d3a2c3.collection.tutorials.globus.org:443',
+      }),
+    ).toBe('collection.tutorials.globus.org');
+
+    expect(
+      getDomainFromEndpoint({
+        tlsftp_server: 'tlsftp://m-4d5adb.fa5e.bd7c.data.globus.org:443',
+      }),
+    ).toBe('m-4d5adb.fa5e.bd7c.data.globus.org');
+  });
+
+  it('should return null for invalid objects', () => {
+    expect(getDomainFromEndpoint({})).toBeNull();
+    expect(
+      getDomainFromEndpoint({
+        tlsftp_server: null,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/lib/services/transfer/__tests__/utils.spec.ts
+++ b/src/lib/services/transfer/__tests__/utils.spec.ts
@@ -4,16 +4,20 @@ describe('readableBytes', () => {
   it('should return the correct readable string for bytes', () => {
     expect(readableBytes(90)).toBe('90 B');
     expect(readableBytes(1024)).toBe('1.02 KB');
-    expect(readableBytes(1048576)).toBe('1.05 MB');
+    expect(readableBytes(1048576)).toBe('1.04 MB');
     expect(readableBytes(1073741824)).toBe('1.07 GB');
-    expect(readableBytes(1099511627776)).toBe('1.10 TB');
-    expect(readableBytes(1125899906842624)).toBe('1.13 PB');
+    expect(readableBytes(1099511627776)).toBe('1.09 TB');
+    expect(readableBytes(1125899906842624)).toBe('1.12 PB');
   });
 
   it('should truncate the readable string based on the truncate parameter', () => {
     expect(readableBytes(1024, 0)).toBe('1 KB');
+    expect(readableBytes(1024, 1)).toBe('1.0 KB');
+    expect(readableBytes(1024, 2)).toBe('1.02 KB');
+    expect(readableBytes(1024, 3)).toBe('1.024 KB');
+    expect(readableBytes(1024, 4)).toBe('1.024 KB');
     expect(readableBytes(1048576, 1)).toBe('1.0 MB');
-    expect(readableBytes(1073741824, 3)).toBe('1.074 GB');
+    expect(readableBytes(1073741824, 3)).toBe('1.073 GB');
   });
 });
 

--- a/src/lib/services/transfer/__tests__/utils.spec.ts
+++ b/src/lib/services/transfer/__tests__/utils.spec.ts
@@ -1,0 +1,55 @@
+import { readableBytes, isDirectory, isFileDocument } from '../utils';
+
+describe('readableBytes', () => {
+  it('should return the correct readable string for bytes', () => {
+    expect(readableBytes(90)).toBe('90 B');
+    expect(readableBytes(1024)).toBe('1.02 KB');
+    expect(readableBytes(1048576)).toBe('1.05 MB');
+    expect(readableBytes(1073741824)).toBe('1.07 GB');
+    expect(readableBytes(1099511627776)).toBe('1.10 TB');
+    expect(readableBytes(1125899906842624)).toBe('1.13 PB');
+  });
+
+  it('should truncate the readable string based on the truncate parameter', () => {
+    expect(readableBytes(1024, 0)).toBe('1 KB');
+    expect(readableBytes(1048576, 1)).toBe('1.0 MB');
+    expect(readableBytes(1073741824, 3)).toBe('1.074 GB');
+  });
+});
+
+/**
+ * @see https://docs.globus.org/api/transfer/file_operations/#file_document
+ */
+const FILE = {
+  DATA_TYPE: 'file',
+  type: 'file',
+};
+
+const DIR = {
+  ...FILE,
+  type: 'dir',
+};
+
+const INVALID_SYMLINK = {
+  ...FILE,
+  type: 'invalid_symlink',
+};
+
+describe('isDirectory', () => {
+  it('should return true for directory objects', () => {
+    expect(isDirectory(DIR)).toBe(true);
+  });
+
+  it('should return false for non-directory objects', () => {
+    expect(isDirectory(FILE)).toBe(false);
+    expect(isDirectory(INVALID_SYMLINK)).toBe(false);
+  });
+});
+
+describe('isFileDocument', () => {
+  it('should return true for all "File Document" objects', () => {
+    expect(isFileDocument(FILE)).toBe(true);
+    expect(isFileDocument(DIR)).toBe(true);
+    expect(isFileDocument(INVALID_SYMLINK)).toBe(true);
+  });
+});

--- a/src/lib/services/transfer/index.ts
+++ b/src/lib/services/transfer/index.ts
@@ -23,3 +23,5 @@ export * as access from './service/access.js';
 export * as collectionBookmarks from './service/collection-bookmarks.js';
 
 export * as endpointManager from './service/endpoint-manager/index.js';
+
+export * as utils from './utils.js';

--- a/src/lib/services/transfer/utils.ts
+++ b/src/lib/services/transfer/utils.ts
@@ -1,0 +1,14 @@
+import type { FileDocument } from './service/file-operations';
+
+export function isFileDocument(entry: unknown): entry is FileDocument {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    'DATA_TYPE' in entry &&
+    entry.DATA_TYPE === 'file'
+  );
+}
+
+export function isDirectory(entry: unknown) {
+  return isFileDocument(entry) && entry.type === 'dir';
+}

--- a/src/lib/services/transfer/utils.ts
+++ b/src/lib/services/transfer/utils.ts
@@ -53,7 +53,15 @@ export function readableBytes(bytes: number, truncate = 2) {
     bytesInUnit = PB;
   }
   const value = bytes / bytesInUnit;
-  return `${value.toFixed(truncate)} ${unit}`;
+  const [int, dec] = `${value}`.split('.');
+  let rendered = `${int}`;
+  if (dec && dec.length) {
+    const truncated = dec.slice(0, truncate);
+    if (truncated.length) {
+      rendered = `${int}.${truncated}`;
+    }
+  }
+  return `${rendered} ${unit}`;
 }
 
 /**

--- a/src/lib/services/transfer/utils.ts
+++ b/src/lib/services/transfer/utils.ts
@@ -1,5 +1,9 @@
-import type { FileDocument } from './service/file-operations';
+import type { FileDocument } from './service/file-operations.js';
 
+/**
+ * Determines if the given entry is a Globus Transfer File Document.
+ * @see https://docs.globus.org/api/transfer/file_operations/#file_document
+ */
 export function isFileDocument(entry: unknown): entry is FileDocument {
   return (
     typeof entry === 'object' &&
@@ -8,7 +12,46 @@ export function isFileDocument(entry: unknown): entry is FileDocument {
     entry.DATA_TYPE === 'file'
   );
 }
-
+/**
+ * Determines if the given entry is a directory.
+ * @see https://docs.globus.org/api/transfer/file_operations/#file_document
+ */
 export function isDirectory(entry: unknown) {
   return isFileDocument(entry) && entry.type === 'dir';
+}
+
+const KB = 1000;
+const MB = KB * 1000;
+const GB = MB * 1000;
+const TB = GB * 1000;
+const PB = TB * 1000;
+/**
+ * Returns a readable string for the given bytes, **rounded and truncated** to the given number of decimal places.
+ * @param bytes The number of bytes to convert to a readable string.
+ * @param [truncate=2] The number of decimal places to truncate the result to.
+ */
+export function readableBytes(bytes: number, truncate = 2) {
+  let unit = 'B';
+  let bytesInUnit = 1;
+  if (bytes < KB) {
+    return `${bytes} ${unit}`;
+  }
+  if (bytes < MB) {
+    unit = 'KB';
+    bytesInUnit = KB;
+  } else if (bytes < GB) {
+    unit = 'MB';
+    bytesInUnit = MB;
+  } else if (bytes < TB) {
+    unit = 'GB';
+    bytesInUnit = GB;
+  } else if (bytes < PB) {
+    unit = 'TB';
+    bytesInUnit = TB;
+  } else {
+    unit = 'PB';
+    bytesInUnit = PB;
+  }
+  const value = bytes / bytesInUnit;
+  return `${value.toFixed(truncate)} ${unit}`;
 }


### PR DESCRIPTION
feat: adds `transfer.utils.readableBytes()`
  - This is used in the portals and Globus Web Application for rendering file sizes.

feat: adds `transfer.utils.isDirectory()` and `transfer.utils.isFileDocument()`
  - Used in the portals and Globus Web Application for determining more specific types from `Globus.Transfer.FileDocument`