### PR TITLE
fix(Authorization): The RedirectTransport (used by the AuthorizationManager), will now call `location.assign` instead of `location.replace` on the initialization of the OAuth process. This will ensure users can use the "back" button from the Globus Auth page.

### DIFF
--- a/src/__mocks__/window-location.ts
+++ b/src/__mocks__/window-location.ts
@@ -2,6 +2,9 @@ let URL_BAR = new URL('https://jest_url_bar');
 Object.defineProperty(globalThis, 'window', {
   value: {
     location: {
+      assign: jest.fn().mockImplementation((url) => {
+        URL_BAR = new URL(url);
+      }),
       replace: jest.fn().mockImplementation((url) => {
         URL_BAR = new URL(url);
       }),

--- a/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
+++ b/src/lib/core/__tests__/authorization/AuthorizationManager.spec.ts
@@ -38,8 +38,8 @@ describe('AuthorizationManager', () => {
     expect(instance).toBeDefined();
     expect(instance.authenticated).toBe(false);
     instance.login();
-    expect(window.location.replace).toHaveBeenCalledTimes(1);
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
       expect.stringContaining('scope=openid+profile+email&'),
     );
   });
@@ -217,8 +217,8 @@ describe('AuthorizationManager', () => {
       scopes: 'foobar baz',
     });
     instance.login();
-    expect(window.location.replace).toHaveBeenCalledTimes(1);
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
       expect.stringContaining(
         'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email&redirect_uri=https%3A%2F%2Fredirect_uri',
       ),
@@ -285,8 +285,8 @@ describe('AuthorizationManager', () => {
         defaultScopes: 'openid',
       });
       instance.login();
-      expect(window.location.replace).toHaveBeenCalledTimes(1);
-      expect(window.location.replace).toHaveBeenCalledWith(
+      expect(window.location.assign).toHaveBeenCalledTimes(1);
+      expect(window.location.assign).toHaveBeenCalledWith(
         expect.stringContaining(
           'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid&redirect_uri=https%3A%2F%2Fredirect_uri',
         ),
@@ -301,8 +301,8 @@ describe('AuthorizationManager', () => {
         defaultScopes: false,
       });
       instance.login();
-      expect(window.location.replace).toHaveBeenCalledTimes(1);
-      expect(window.location.replace).toHaveBeenCalledWith(
+      expect(window.location.assign).toHaveBeenCalledTimes(1);
+      expect(window.location.assign).toHaveBeenCalledWith(
         expect.stringContaining(
           'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz&redirect_uri=https%3A%2F%2Fredirect_uri',
         ),
@@ -318,8 +318,8 @@ describe('AuthorizationManager', () => {
       useRefreshTokens: true,
     });
     instance.login();
-    expect(window.location.replace).toHaveBeenCalledTimes(1);
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
       expect.stringContaining(
         'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email+offline_access&redirect_uri=https%3A%2F%2Fredirect_uri',
       ),

--- a/src/lib/core/__tests__/authorization/RedirectTransport.spec.ts
+++ b/src/lib/core/__tests__/authorization/RedirectTransport.spec.ts
@@ -25,11 +25,11 @@ describe('RedirectTransport', () => {
     jest.resetAllMocks();
   });
 
-  it('should authorize using the window.location.replace method', async () => {
+  it('should authorize using the window.location.assign method', async () => {
     const transport = new RedirectTransport(MOCK_CONFIG);
     transport.send();
-    expect(window.location.replace).toHaveBeenCalled();
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledWith(
       expect.stringContaining(
         'AUTHORIZATION_ENDPOINT?response_type=code&client_id=CLIENT_ID&state=&scope=REQUIRED_SCOPES&redirect_uri=https%3A%2F%2Fredirect_uri%2Fmy-page',
       ),
@@ -66,8 +66,8 @@ describe('RedirectTransport', () => {
       window.location.href = `${MOCK_CONFIG.redirect_uri}?code=CODE&state=SOME_STATE`;
       const response = await transport.getToken({ shouldReplace: false });
       expect(response).toBe(MOCK_TOKEN);
-      expect(window.location.replace).not.toHaveBeenCalled();
-      expect(window.location.replace).not.toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect_uri));
+      expect(window.location.assign).not.toHaveBeenCalled();
+      expect(window.location.assign).not.toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect_uri));
       expect(window.location.href).toEqual(url);
     });
   });

--- a/src/lib/core/authorization/RedirectTransport.ts
+++ b/src/lib/core/authorization/RedirectTransport.ts
@@ -33,7 +33,7 @@ export class RedirectTransport {
   }
 
   send() {
-    window.location.replace(this.#pkce.authorizeUrl(this.#params));
+    window.location.assign(this.#pkce.authorizeUrl(this.#params));
   }
 
   /**

--- a/src/lib/core/authorization/RedirectTransport.ts
+++ b/src/lib/core/authorization/RedirectTransport.ts
@@ -17,6 +17,15 @@ export type RedirectTransportOptions = IConfig & {
   params?: IObject;
 };
 
+/**
+ * Resets js-pkce state
+ * @see https://github.com/bpedroza/js-pkce/blob/master/src/PKCE.ts
+ */
+function resetPKCE() {
+  sessionStorage.removeItem('pkce_state');
+  sessionStorage.removeItem('pkce_code_verifier');
+}
+
 export class RedirectTransport {
   #pkce: PKCE;
 
@@ -33,6 +42,11 @@ export class RedirectTransport {
   }
 
   send() {
+    /**
+     * By resetting PKCE before sending, we ensure that a fresh `code_challenge` is generated
+     * when `authorizeUrl` is called.
+     */
+    resetPKCE();
     window.location.assign(this.#pkce.authorizeUrl(this.#params));
   }
 
@@ -48,12 +62,7 @@ export class RedirectTransport {
      */
     if (!params.get('code')) return undefined;
     const response = await this.#pkce.exchangeForAccessToken(url.toString());
-    /**
-     * Resets js-pkce state
-     * @see https://github.com/bpedroza/js-pkce/blob/master/src/PKCE.ts
-     */
-    sessionStorage.removeItem('pkce_state');
-    sessionStorage.removeItem('pkce_code_verifier');
+    resetPKCE();
     if (options.shouldReplace) {
       /**
        * Remove the `code` and `state` parameters from the URL.


### PR DESCRIPTION
fix(Authorization): ensure PKCE state is reset before initiating a new OAuth flow