### PR TITLE
feat(Search): Adds methods for interacting and management of Globus Search indicies via (e.g. `search.index.create()`, `search.index.ingest()`)

### DIFF
--- a/src/lib/services/search/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/lib/services/search/__tests__/__snapshots__/index.spec.ts.snap
@@ -48,6 +48,22 @@ exports[`search – index getAll 1`] = `
 }
 `;
 
+exports[`search – index ingest 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "85",
+    "content-type": "application/json",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "POST",
+  "url": "https://search.api.globus.org/v1/index/some-uuid/ingest",
+}
+`;
+
 exports[`search – index remove 1`] = `
 {
   "headers": {
@@ -59,5 +75,20 @@ exports[`search – index remove 1`] = `
   },
   "method": "DELETE",
   "url": "https://search.api.globus.org/v1/index/some-uuid",
+}
+`;
+
+exports[`search – index reopen 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "0",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "POST",
+  "url": "https://search.api.globus.org/v1/index/some-uuid/reopen",
 }
 `;

--- a/src/lib/services/search/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/lib/services/search/__tests__/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`search – index create 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "61",
+    "content-type": "application/json",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "json": {
+    "description": "example description",
+    "display_name": "foobar",
+  },
+  "method": "POST",
+  "url": "https://search.api.globus.org/v1/index",
+}
+`;
+
+exports[`search – index get 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://search.api.globus.org/v1/index/524de2f6-d1a6-4b49-9286-d8dccb4196ae",
+}
+`;
+
+exports[`search – index getAll 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://search.api.globus.org/v1/index_list",
+}
+`;
+
+exports[`search – index remove 1`] = `
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "search.api.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "DELETE",
+  "url": "https://search.api.globus.org/v1/index/some-uuid",
+}
+`;

--- a/src/lib/services/search/__tests__/index.spec.ts
+++ b/src/lib/services/search/__tests__/index.spec.ts
@@ -2,7 +2,7 @@ import { index } from '..';
 
 import { mirror } from '../../../../__mocks__/handlers';
 
-describe.only('search – index', () => {
+describe('search – index', () => {
   test('get', async () => {
     const request = await index.get('524de2f6-d1a6-4b49-9286-d8dccb4196ae');
     const {
@@ -44,6 +44,40 @@ describe.only('search – index', () => {
 
   test('remove', async () => {
     const request = await index.remove('some-uuid');
+    const {
+      req: { url, method, headers },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('reopen', async () => {
+    const request = await index.reopen('some-uuid');
+    const {
+      req: { url, method, headers },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('ingest', async () => {
+    const request = await index.ingest('some-uuid', {
+      payload: {
+        ingest_type: 'GMetaEntry',
+        ingest_data: {
+          subject: 'test',
+          content: {
+            foo: 'bar',
+          },
+        },
+      },
+    });
     const {
       req: { url, method, headers },
     } = await mirror(request);

--- a/src/lib/services/search/__tests__/index.spec.ts
+++ b/src/lib/services/search/__tests__/index.spec.ts
@@ -1,0 +1,56 @@
+import { index } from '..';
+
+import { mirror } from '../../../../__mocks__/handlers';
+
+describe.only('search – index', () => {
+  test('get', async () => {
+    const request = await index.get('524de2f6-d1a6-4b49-9286-d8dccb4196ae');
+    const {
+      req: { url, method, headers },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('getAll', async () => {
+    const request = await index.getAll();
+    const {
+      req: { url, method, headers },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+
+  test('create', async () => {
+    const request = await index.create({
+      payload: { display_name: 'foobar', description: 'example description' },
+    });
+    const {
+      req: { url, method, headers, json },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+      json,
+    }).toMatchSnapshot();
+  });
+
+  test('remove', async () => {
+    const request = await index.remove('some-uuid');
+    const {
+      req: { url, method, headers },
+    } = await mirror(request);
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchSnapshot();
+  });
+});

--- a/src/lib/services/search/__tests__/query.spec.ts
+++ b/src/lib/services/search/__tests__/query.spec.ts
@@ -1,19 +1,19 @@
 import { createStorage } from '../../../core/storage';
 import { query } from '..';
 
-import { MirroredRequest, mirror } from '../../../../__mocks__/handlers';
+import { mirror } from '../../../../__mocks__/handlers';
 
 describe('search – query', () => {
   test('get', async () => {
     createStorage('memory');
-    const result = await query.get('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {
+    const request = await query.get('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {
       query: {
         q: 'test',
       },
     });
     const {
       req: { url, method, headers },
-    } = (await result.json()) as MirroredRequest;
+    } = await mirror(request);
     expect({
       url,
       method,
@@ -62,12 +62,12 @@ describe('search – query', () => {
 
   test('post', async () => {
     createStorage('memory');
-    const result = await query.post('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {
+    const request = await query.post('524de2f6-d1a6-4b49-9286-d8dccb4196ae', {
       payload: { q: 'test' },
     });
     const {
       req: { url, method, headers, json },
-    } = (await result.json()) as unknown as MirroredRequest;
+    } = await mirror(request);
     expect({
       url,
       method,

--- a/src/lib/services/search/index.ts
+++ b/src/lib/services/search/index.ts
@@ -15,3 +15,4 @@ export const CONFIG = SEARCH;
 export * as query from './service/query.js';
 export * as subject from './service/subject.js';
 export * as entry from './service/entry.js';
+export * as index from './service/search-index.js';

--- a/src/lib/services/search/service/query.ts
+++ b/src/lib/services/search/service/query.ts
@@ -3,13 +3,56 @@ import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 import type { JSONFetchResponse, ServiceMethodDynamicSegments } from '../../types.js';
 
 import { ID, SCOPES } from '../config.js';
+import { ResultFormatVersion } from '../types.js';
+
+type GMetaResult = {
+  subject: string;
+  entries: {
+    entry_id: string;
+    content: Record<string, unknown>;
+    matched_principal_sets: string[];
+  }[];
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gfacetresult
+ */
+export type GFacetResult = {
+  name: string;
+  value?: string;
+  buckets?: GBucket[];
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gbucket
+ */
+export type GBucket = {
+  value: string | Globus.Search.GFilter;
+  count: number;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gsearchresult
+ */
+export type GSearchResult = {
+  gmeta: GMetaResult;
+  facet_result?: GFacetResult[];
+  offset: number;
+  count: number;
+  total: number;
+  has_next_page: boolean;
+};
 
 /**
  * @param index_id The UUID of the index to query.
  *
  * @see https://docs.globus.org/api/search/reference/get_query/
  */
-export const get = function (index_id, options?, sdkOptions?) {
+export const get = function (
+  index_id,
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<GSearchResult>> {
   return serviceRequest(
     {
       service: ID,
@@ -46,7 +89,7 @@ export const post = function (
   index_id,
   options,
   sdkOptions?,
-): Promise<JSONFetchResponse<Globus.Search.GSearchResult>> {
+): Promise<JSONFetchResponse<GSearchResult>> {
   return serviceRequest(
     {
       service: ID,
@@ -69,12 +112,12 @@ export const post = function (
       limit?: number;
       advanced?: boolean;
       bypass_visible_to?: boolean;
-      result_format_version?: Globus.Search.ResultFormatVersion;
-      filter_principal_sets?: Array<string>;
-      filters?: Array<Globus.Search.GFilter>;
-      facets?: Array<Globus.Search.GFacet>;
-      boosts?: Array<Globus.Search.GBoost>;
-      sort?: Array<Globus.Search.GSort>;
+      result_format_version?: ResultFormatVersion;
+      filter_principal_sets?: string[];
+      filters?: Globus.Search.GFilter[];
+      facets?: Globus.Search.GFacet[];
+      boosts?: Globus.Search.GBoost[];
+      sort?: Globus.Search.GSort[];
     };
   }
 >;

--- a/src/lib/services/search/service/query.ts
+++ b/src/lib/services/search/service/query.ts
@@ -5,7 +5,10 @@ import type { JSONFetchResponse, ServiceMethodDynamicSegments } from '../../type
 import { ID, SCOPES } from '../config.js';
 import { ResultFormatVersion } from '../types.js';
 
-type GMetaResult = {
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gmetaresult
+ */
+export type GMetaResult = {
   subject: string;
   entries: {
     entry_id: string;
@@ -154,7 +157,7 @@ type HistogramRange = { low: number | string; high: number | string };
 /**
  * @see https://docs.globus.org/api/search/reference/post_query/#gfacet
  */
-type GFacet = {
+export type GFacet = {
   name: string;
   field_name: string;
 } & (
@@ -183,7 +186,7 @@ type DateInterval = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'mi
 /**
  * @see https://docs.globus.org/api/search/reference/post_query/#gboost
  */
-type GBoost = {
+export type GBoost = {
   field_name: string;
   factor: number;
 };
@@ -191,7 +194,7 @@ type GBoost = {
 /**
  * @see https://docs.globus.org/api/search/reference/post_query/#gsort
  */
-type GSort = {
+export type GSort = {
   field_name: string;
   order: 'asc' | 'desc';
 };

--- a/src/lib/services/search/service/query.ts
+++ b/src/lib/services/search/service/query.ts
@@ -27,7 +27,7 @@ export type GFacetResult = {
  * @see https://docs.globus.org/api/search/reference/post_query/#gbucket
  */
 export type GBucket = {
-  value: string | Globus.Search.GFilter;
+  value: string | GFilter;
   count: number;
 };
 
@@ -114,10 +114,84 @@ export const post = function (
       bypass_visible_to?: boolean;
       result_format_version?: ResultFormatVersion;
       filter_principal_sets?: string[];
-      filters?: Globus.Search.GFilter[];
-      facets?: Globus.Search.GFacet[];
-      boosts?: Globus.Search.GBoost[];
-      sort?: Globus.Search.GSort[];
+      filters?: GFilter[];
+      facets?: GFacet[];
+      boosts?: GBoost[];
+      sort?: GSort[];
     };
   }
 >;
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gfilter
+ */
+export type GFilter = GFilterMatch | GFilterRange | GFilterExists | GFilterNot;
+
+type GFilterTypeMatch = 'match_any' | 'match_all';
+type GFilterTypeRange = 'range';
+
+type GFilterMatch = {
+  type: GFilterTypeMatch;
+  field_name: string;
+  values: Array<string>;
+};
+type GFilterRange = {
+  type: GFilterTypeRange;
+  field_name: string;
+  values: Array<{ from: string; to: string }>;
+};
+type GFilterExists = {
+  type: 'exists';
+  field_name: string;
+};
+type GFilterNot = {
+  type: 'not';
+  filter: GFilter;
+};
+
+type HistogramRange = { low: number | string; high: number | string };
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gfacet
+ */
+type GFacet = {
+  name: string;
+  field_name: string;
+} & (
+  | {
+      type: 'terms';
+    }
+  | {
+      type: 'sum' | 'avg';
+      missing?: number;
+    }
+  | {
+      type: 'date_histogram';
+      date_interval: DateInterval;
+      histogram_range?: HistogramRange;
+    }
+  | {
+      type: 'numeric_histogram';
+      size: string;
+      interval: number;
+      histogram_range: HistogramRange;
+    }
+);
+
+type DateInterval = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gboost
+ */
+type GBoost = {
+  field_name: string;
+  factor: number;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/post_query/#gsort
+ */
+type GSort = {
+  field_name: string;
+  order: 'asc' | 'desc';
+};

--- a/src/lib/services/search/service/search-index.ts
+++ b/src/lib/services/search/service/search-index.ts
@@ -1,0 +1,218 @@
+import { HTTP_METHODS, serviceRequest } from '../../shared.js';
+import { ID, SCOPES } from '../config.js';
+
+import type {
+  JSONFetchResponse,
+  ServiceMethod,
+  ServiceMethodDynamicSegments,
+} from '../../types.js';
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_list/#indexwithpermissions
+ */
+type IndexWithPermissions = {
+  permissions: string[];
+  display_name: string;
+  id: string;
+  description: string;
+  creation_date: string;
+  is_trial: boolean;
+  subscription_id: string;
+  max_size_in_mb: number;
+  size_in_mb: number;
+  num_subjects: number;
+  num_entries: number;
+};
+
+type GSearchIndex = {
+  display_name: string;
+  id: string;
+  description: string;
+  creation_date: string;
+  is_trial: boolean;
+  subscription_id: string;
+  max_size_in_mb: number;
+  size_in_mb: number;
+  num_subjects: number;
+  num_entries: number;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_show/
+ */
+export const get = function (
+  index_id,
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<GSearchIndex>> {
+  return serviceRequest(
+    {
+      service: ID,
+      // scope: SCOPES.ALL,
+      path: `/v1/index/${index_id}`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<string, {}>;
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_list/
+ */
+export const getAll = function (
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<IndexWithPermissions[]>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v1/index_list`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethod<{}>;
+
+type IndexCreate = {
+  display_name: string;
+  description: string;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_create/
+ */
+export const create = function (options, sdkOptions?): Promise<JSONFetchResponse<GSearchIndex>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v1/index`,
+      method: HTTP_METHODS.POST,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethod<{
+  payload: IndexCreate;
+}>;
+
+type IndexDeleteResponse = {
+  index_id: string;
+  acknowledged: boolean;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_delete/
+ */
+export const remove = function (
+  index_id,
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<IndexDeleteResponse>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v1/index/${index_id}`,
+      method: HTTP_METHODS.DELETE,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  }
+>;
+
+type IndexReopenResponse = {
+  index_id: string;
+  acknowledged: boolean;
+};
+
+/**
+ * @see https://docs.globus.org/api/search/reference/index_reopen/
+ */
+export const reopen = function (
+  index_id,
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<IndexReopenResponse>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v1/index/${index_id}/reopen`,
+      method: HTTP_METHODS.POST,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    query?: never;
+    payload?: never;
+  }
+>;
+
+type IngestResponse = {
+  task_id: string;
+  as_identity: string;
+  success: boolean;
+  num_documents_ingested: number;
+};
+
+type GIngest =
+  | {
+      ingest_type: string;
+      ingest_data: Record<string, unknown>;
+      field_mapping: Record<string, unknown>;
+    }
+  | {
+      ingest_type: 'GMetaList';
+      ingest_data: GMetaList;
+      field_mapping: Record<string, unknown>;
+    }
+  | {
+      ingest_type: 'GMetaEntry';
+      ingest_data: GMetaEntry;
+      field_mapping: Record<string, unknown>;
+    };
+
+type GMetaList = {
+  gmeta: GMetaEntry[];
+};
+
+type GMetaEntry = {
+  id: string;
+  subject: string;
+  visible_to: string | 'public' | 'all_authenticated_users';
+  principal_sets: Record<string, unknown>;
+  content: Record<string, unknown>;
+};
+
+export const ingest = function (
+  index_id,
+  options?,
+  sdkOptions?,
+): Promise<JSONFetchResponse<IngestResponse>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.ALL,
+      path: `/v1/index/${index_id}/ingest`,
+      method: HTTP_METHODS.POST,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<
+  string,
+  {
+    payload: GIngest;
+  }
+>;

--- a/src/lib/services/search/service/search-index.ts
+++ b/src/lib/services/search/service/search-index.ts
@@ -166,27 +166,44 @@ type IngestResponse = {
   num_documents_ingested: number;
 };
 
+/**
+ * A mapping from field names (dotted) to the types for those fields. Currently only supports `geo_point` and `geo_shape` as types.
+ */
+type FieldMapping = Record<string, 'geo_point' | 'geo_shape' | string>;
+
+/**
+ * A `GIngest` document is a wrapper around a {@link GMetaList} or {@link GMetaEntry} which supplies attributes relevant to the ingest and indexing of metadata into the Globus Search service.
+ * @see https://docs.globus.org/api/search/reference/ingest/#gingest
+ */
 type GIngest =
   | {
       ingest_type: string;
       ingest_data: Record<string, unknown>;
-      field_mapping: Record<string, unknown>;
+      field_mapping?: FieldMapping;
     }
   | {
       ingest_type: 'GMetaList';
       ingest_data: GMetaList;
-      field_mapping: Record<string, unknown>;
+      field_mapping?: FieldMapping;
     }
   | {
       ingest_type: 'GMetaEntry';
       ingest_data: GMetaEntry;
-      field_mapping: Record<string, unknown>;
+      field_mapping?: FieldMapping;
     };
 
+/**
+ * A GMetaList is a collection of {@link GMetaEntry} documents.
+ * @see https://docs.globus.org/api/search/reference/ingest/#gmetalist
+ */
 type GMetaList = {
   gmeta: GMetaEntry[];
 };
 
+/**
+ * A GMetaEntry is a single block of data pertaining to a given subject.
+ * @see https://docs.globus.org/api/search/reference/ingest/#gmetaentry
+ */
 type GMetaEntry = {
   id: string;
   subject: string;

--- a/src/lib/services/search/service/search-index.ts
+++ b/src/lib/services/search/service/search-index.ts
@@ -205,9 +205,9 @@ type GMetaList = {
  * @see https://docs.globus.org/api/search/reference/ingest/#gmetaentry
  */
 type GMetaEntry = {
-  id: string;
+  id?: string;
   subject: string;
-  visible_to: string | 'public' | 'all_authenticated_users';
+  visible_to: 'public' | 'all_authenticated_users' | string;
   principal_sets: Record<string, unknown>;
   content: Record<string, unknown>;
 };

--- a/src/lib/services/search/types.ts
+++ b/src/lib/services/search/types.ts
@@ -1,1 +1,12 @@
 export type ResultFormatVersion = '2019-08-27' | '2017-09-01';
+
+/**
+ * @see https://docs.globus.org/api/search/errors/
+ */
+export type GError = {
+  message: string;
+  code: string;
+  request_id: string;
+  status: number;
+  error_data?: Record<string, unknown> | GError[];
+};


### PR DESCRIPTION
feat(Search, Typescript): Moves most Globus Search types internal to the SDK (previously sourced from `@globus/types`)