### PR TITLE
fix(Authorization): updates PKCE integration to use native API (drops js-pkce package)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "^4.0.0",
-        "js-pkce": "^1.2.1",
         "jwt-decode": "^4.0.0"
       },
       "devDependencies": {
@@ -3409,11 +3408,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5914,14 +5908,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/js-pkce": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/js-pkce/-/js-pkce-1.4.0.tgz",
-      "integrity": "sha512-ztPzIgjQ+hY2uvwsTi625Yt/123NODAInGg2Y7aQLlKpNpD16A3WePjKyY2+B8WCoZy1cGG4xC9C68Dt2ZB8iQ==",
-      "dependencies": {
-        "crypto-js": "^4.0.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
   },
   "dependencies": {
     "cross-fetch": "^4.0.0",
-    "js-pkce": "^1.2.1",
     "jwt-decode": "^4.0.0"
   },
   "peerDependencies": {

--- a/src/core/__tests__/authorization/AuthorizationManager.spec.ts
+++ b/src/core/__tests__/authorization/AuthorizationManager.spec.ts
@@ -1,4 +1,3 @@
-import PKCE from 'js-pkce';
 import { HttpResponse, http } from 'msw';
 import { setup } from '../../../__mocks__/localStorage';
 import server from '../../../__mocks__/server';
@@ -8,6 +7,8 @@ import { AuthorizationManager } from '../../authorization/AuthorizationManager';
 import { Event } from '../../authorization/Event';
 import { TRANSFER_CONSENT_REQUIRED_ERROR, TRANSFER_GENERIC_ERROR } from '../errors.spec';
 import { TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR } from '../../../__mocks__/errors/authorization_parameters';
+import { oauth2 } from '../../../services/auth';
+import { RedirectTransport } from '../../authorization/RedirectTransport';
 
 describe('AuthorizationManager', () => {
   beforeEach(() => {
@@ -30,19 +31,136 @@ describe('AuthorizationManager', () => {
     expect(instance.authenticated).toBe(false);
   });
 
-  it('can be created without providing scopes', () => {
-    const instance = new AuthorizationManager({
-      client: 'client_id',
-      redirect: 'https://redirect_uri',
+  if (RedirectTransport.supported) {
+    describe('RedirectTransport', () => {
+      it('can be created without providing scopes', () => {
+        const instance = new AuthorizationManager({
+          client: 'client_id',
+          redirect: 'https://redirect_uri',
+        });
+        expect(instance).toBeDefined();
+        expect(instance.authenticated).toBe(false);
+        instance.login();
+        expect(window.location.assign).toHaveBeenCalledTimes(1);
+        expect(window.location.assign).toHaveBeenCalledWith(
+          expect.stringContaining('scope=openid+profile+email&'),
+        );
+      });
+
+      it('supports login', () => {
+        const instance = new AuthorizationManager({
+          client: 'client_id',
+          redirect: 'https://redirect_uri',
+          scopes: 'foobar baz',
+        });
+        instance.login();
+        expect(window.location.assign).toHaveBeenCalledTimes(1);
+        expect(window.location.assign).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email&redirect_uri=https%3A%2F%2Fredirect_uri',
+          ),
+        );
+      });
+
+      it('supports login with additionalParameters', () => {
+        const instance = new AuthorizationManager({
+          client: 'client_id',
+          redirect: 'https://redirect_uri',
+          scopes: 'foobar baz',
+        });
+        instance.login({
+          additionalParams: {
+            page: 'some.example.state',
+          },
+        });
+        const url = new URL(window.location.href);
+        expect(url.searchParams.get('page')).toBe('some.example.state');
+      });
+
+      describe('defaultScopes', () => {
+        it('supports custom value', () => {
+          const instance = new AuthorizationManager({
+            client: 'client_id',
+            redirect: 'https://redirect_uri',
+            scopes: 'foobar baz',
+            defaultScopes: 'openid',
+          });
+          instance.login();
+          expect(window.location.assign).toHaveBeenCalledTimes(1);
+          expect(window.location.assign).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid&redirect_uri=https%3A%2F%2Fredirect_uri',
+            ),
+          );
+        });
+
+        it('can be disabled', () => {
+          const instance = new AuthorizationManager({
+            client: 'client_id',
+            redirect: 'https://redirect_uri',
+            scopes: 'foobar baz',
+            defaultScopes: false,
+          });
+          instance.login();
+          expect(window.location.assign).toHaveBeenCalledTimes(1);
+          expect(window.location.assign).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz&redirect_uri=https%3A%2F%2Fredirect_uri',
+            ),
+          );
+        });
+
+        it('requests "offline_access" with useRefreshTokens', () => {
+          const instance = new AuthorizationManager({
+            client: 'client_id',
+            redirect: 'https://redirect_uri',
+            scopes: 'foobar baz',
+            useRefreshTokens: true,
+          });
+          instance.login();
+          expect(window.location.assign).toHaveBeenCalledTimes(1);
+          expect(window.location.assign).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email+offline_access&redirect_uri=https%3A%2F%2Fredirect_uri',
+            ),
+          );
+        });
+      });
+
+      it('handleCodeRedirect', async () => {
+        const MOCK_TOKEN = {
+          access_token: 'ACCESS_TOKEN',
+          expires_in: 12000,
+          token_type: 'Bearer',
+          resource_server: 'auth.globus.org',
+          state: 'STATE',
+          scope: 'openid profile email',
+        };
+
+        const CONFIG = {
+          client: 'client_id',
+          redirect: 'https://redirect_uri',
+          scopes: '',
+        };
+
+        jest
+          .spyOn(oauth2.token, 'token')
+          .mockReturnValue(Promise.resolve(Response.json(MOCK_TOKEN)));
+
+        const instance = new AuthorizationManager(CONFIG);
+        const spy = jest.spyOn(instance.events.authenticated, 'dispatch');
+
+        window.location.href = 'https://redirect_uri?code=CODE';
+        await instance.handleCodeRedirect();
+        expect(instance.authenticated).toBe(true);
+        expect(spy).toHaveBeenCalledWith({
+          isAuthenticated: true,
+          token: MOCK_TOKEN,
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
-    expect(instance).toBeDefined();
-    expect(instance.authenticated).toBe(false);
-    instance.login();
-    expect(window.location.assign).toHaveBeenCalledTimes(1);
-    expect(window.location.assign).toHaveBeenCalledWith(
-      expect.stringContaining('scope=openid+profile+email&'),
-    );
-  });
+  }
 
   it('throws if no "client" is provided', () => {
     expect(() => {
@@ -210,36 +328,6 @@ describe('AuthorizationManager', () => {
     expect(instance.authenticated).toBe(true);
   });
 
-  it('supports login', () => {
-    const instance = new AuthorizationManager({
-      client: 'client_id',
-      redirect: 'https://redirect_uri',
-      scopes: 'foobar baz',
-    });
-    instance.login();
-    expect(window.location.assign).toHaveBeenCalledTimes(1);
-    expect(window.location.assign).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email&redirect_uri=https%3A%2F%2Fredirect_uri',
-      ),
-    );
-  });
-
-  it('supports login with additionalParameters', () => {
-    const instance = new AuthorizationManager({
-      client: 'client_id',
-      redirect: 'https://redirect_uri',
-      scopes: 'foobar baz',
-    });
-    instance.login({
-      additionalParams: {
-        page: 'some.example.state',
-      },
-    });
-    const url = new URL(window.location.href);
-    expect(url.searchParams.get('page')).toBe('some.example.state');
-  });
-
   describe('user', () => {
     it('returns null when no Globus Auth token is present', () => {
       const instance = new AuthorizationManager({
@@ -274,93 +362,6 @@ describe('AuthorizationManager', () => {
         iat: 1516239022,
       });
     });
-  });
-
-  describe('defaultScopes', () => {
-    it('supports custom value', () => {
-      const instance = new AuthorizationManager({
-        client: 'client_id',
-        redirect: 'https://redirect_uri',
-        scopes: 'foobar baz',
-        defaultScopes: 'openid',
-      });
-      instance.login();
-      expect(window.location.assign).toHaveBeenCalledTimes(1);
-      expect(window.location.assign).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid&redirect_uri=https%3A%2F%2Fredirect_uri',
-        ),
-      );
-    });
-
-    it('can be disabled', () => {
-      const instance = new AuthorizationManager({
-        client: 'client_id',
-        redirect: 'https://redirect_uri',
-        scopes: 'foobar baz',
-        defaultScopes: false,
-      });
-      instance.login();
-      expect(window.location.assign).toHaveBeenCalledTimes(1);
-      expect(window.location.assign).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz&redirect_uri=https%3A%2F%2Fredirect_uri',
-        ),
-      );
-    });
-  });
-
-  it('requests "offline_access" with useRefreshTokens', () => {
-    const instance = new AuthorizationManager({
-      client: 'client_id',
-      redirect: 'https://redirect_uri',
-      scopes: 'foobar baz',
-      useRefreshTokens: true,
-    });
-    instance.login();
-    expect(window.location.assign).toHaveBeenCalledTimes(1);
-    expect(window.location.assign).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=client_id&state=&scope=foobar+baz+openid+profile+email+offline_access&redirect_uri=https%3A%2F%2Fredirect_uri',
-      ),
-    );
-  });
-
-  it('handleCodeRedirect', async () => {
-    const MOCK_TOKEN = {
-      access_token: 'ACCESS_TOKEN',
-      expires_in: 12000,
-      token_type: 'Bearer',
-      resource_server: 'auth.globus.org',
-      state: 'STATE',
-      scope: 'openid profile email',
-      /**
-       * @todo These are actually NOT part of the token response, unless requesting `offline_access`, but
-       * js-pkce enforces the presence of these properties.
-       * @see https://github.com/bpedroza/js-pkce/pull/48
-       */
-      refresh_expires_in: 0,
-      refresh_token: 'REFRESH_TOKEN',
-    };
-
-    const CONFIG = {
-      client: 'client_id',
-      redirect: 'https://redirect_uri',
-      scopes: '',
-    };
-    jest.spyOn(PKCE.prototype, 'exchangeForAccessToken').mockImplementation(async () => MOCK_TOKEN);
-
-    const instance = new AuthorizationManager(CONFIG);
-    const spy = jest.spyOn(instance.events.authenticated, 'dispatch');
-
-    window.location.href = 'https://redirect_uri?code=CODE';
-    await instance.handleCodeRedirect();
-    expect(instance.authenticated).toBe(true);
-    expect(spy).toHaveBeenCalledWith({
-      isAuthenticated: true,
-      token: MOCK_TOKEN,
-    });
-    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   describe('reset', () => {
@@ -494,105 +495,107 @@ describe('AuthorizationManager', () => {
   });
 });
 
-describe('AuthorizationManager - Error Utilities', () => {
-  let instance: AuthorizationManager;
+if (RedirectTransport.supported) {
+  describe('AuthorizationManager - Error Utilities', () => {
+    let instance: AuthorizationManager;
 
-  beforeEach(() => {
-    jest.restoreAllMocks();
-    instance = new AuthorizationManager({
-      client: 'CLIENT_ID',
-      redirect: 'https://globus.github.io/example-data-portal/authenticate',
-      scopes: 'urn:globus:auth:scope:transfer.api.globus.org:all',
-    });
-  });
-
-  describe('handleErrorResponse', () => {
-    it('should no-op on an unknown error', () => {
-      const location = window.location.href;
-      instance.handleErrorResponse(TRANSFER_GENERIC_ERROR);
-      expect(window.location.href).toBe(location);
-    });
-
-    it('should handle Authorization Requirements errors', () => {
-      instance.handleErrorResponse(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR);
-      const url = new URL(window.location.href);
-      expect(url.searchParams.get('session_message')).toBe(
-        TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR.authorization_parameters.session_message,
-      );
-      expect(url.searchParams.get('session_required_identities')).toBe('');
-      expect(url.searchParams.get('session_required_mfa')).toBe('false');
-      expect(url.searchParams.get('session_required_single_domain')).toBe('globus.org');
-      expect(url.searchParams.get('prompt')).toBe('login');
-    });
-    it('should handle Consent Required errors', () => {
-      instance.handleErrorResponse(TRANSFER_CONSENT_REQUIRED_ERROR);
-      const url = new URL(window.location.href);
-      expect(url.searchParams.get('scope')).toBe(
-        TRANSFER_CONSENT_REQUIRED_ERROR.required_scopes.join(' '),
-      );
-    });
-    it('should handle AuthenticationFailed errors', () => {
-      const spy = jest.spyOn(instance, 'revoke');
-      instance.handleErrorResponse({
-        code: 'AuthenticationFailed',
-        message: '...',
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      instance = new AuthorizationManager({
+        client: 'CLIENT_ID',
+        redirect: 'https://globus.github.io/example-data-portal/authenticate',
+        scopes: 'urn:globus:auth:scope:transfer.api.globus.org:all',
       });
-      expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it('should return the handler when told not to execute', () => {
-      const location = window.location.href;
-      const handler = instance.handleErrorResponse(
-        {
-          code: 'SomethingHappend',
-          message: '...',
-          authorization_parameters: {
-            session_message: 'This is a session message',
-            session_required_identities: [],
-            session_required_mfa: false,
-            session_required_single_domain: [],
-          },
-        },
-        false,
-      );
-      expect(window.location.href).toBe(location);
-      expect(handler).toBeDefined();
-      expect(handler).toBeInstanceOf(Function);
-      handler();
-
-      const url = new URL(window.location.href);
-      expect(url.searchParams.get('session_message')).toBe('This is a session message');
-      expect(url.searchParams.get('session_required_identities')).toBe('');
-      expect(url.searchParams.get('session_required_mfa')).toBe('false');
-      expect(url.searchParams.get('session_required_single_domain')).toBe('');
-      expect(url.searchParams.get('prompt')).toBe('login');
-    });
-
-    describe('additionalParameters', () => {
-      it('should preserve passed in query parameters for "authorization_requirements" error', () => {
-        instance.handleErrorResponse(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR, {
-          additionalParams: {
-            foo: 'bar',
-          },
-        });
-        const url = new URL(window.location.href);
-        expect(url.searchParams.get('foo')).toBe('bar');
+    describe('handleErrorResponse', () => {
+      it('should no-op on an unknown error', () => {
+        const location = window.location.href;
+        instance.handleErrorResponse(TRANSFER_GENERIC_ERROR);
+        expect(window.location.href).toBe(location);
       });
 
-      it('should preserve passed in query parameters for "ConsentRequired" error', () => {
-        instance.handleErrorResponse(TRANSFER_CONSENT_REQUIRED_ERROR, {
-          additionalParams: {
-            retained_state: 'example-state',
-            retained_route: 'example.route',
-          },
-        });
+      it('should handle Authorization Requirements errors', () => {
+        instance.handleErrorResponse(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR);
         const url = new URL(window.location.href);
-        expect(url.searchParams.get('retained_state')).toBe('example-state');
-        expect(url.searchParams.get('retained_route')).toBe('example.route');
+        expect(url.searchParams.get('session_message')).toBe(
+          TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR.authorization_parameters.session_message,
+        );
+        expect(url.searchParams.get('session_required_identities')).toBe('');
+        expect(url.searchParams.get('session_required_mfa')).toBe('false');
+        expect(url.searchParams.get('session_required_single_domain')).toBe('globus.org');
+        expect(url.searchParams.get('prompt')).toBe('login');
+      });
+      it('should handle Consent Required errors', () => {
+        instance.handleErrorResponse(TRANSFER_CONSENT_REQUIRED_ERROR);
+        const url = new URL(window.location.href);
         expect(url.searchParams.get('scope')).toBe(
           TRANSFER_CONSENT_REQUIRED_ERROR.required_scopes.join(' '),
         );
       });
+      it('should handle AuthenticationFailed errors', () => {
+        const spy = jest.spyOn(instance, 'revoke');
+        instance.handleErrorResponse({
+          code: 'AuthenticationFailed',
+          message: '...',
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should return the handler when told not to execute', () => {
+        const location = window.location.href;
+        const handler = instance.handleErrorResponse(
+          {
+            code: 'SomethingHappend',
+            message: '...',
+            authorization_parameters: {
+              session_message: 'This is a session message',
+              session_required_identities: [],
+              session_required_mfa: false,
+              session_required_single_domain: [],
+            },
+          },
+          false,
+        );
+        expect(window.location.href).toBe(location);
+        expect(handler).toBeDefined();
+        expect(handler).toBeInstanceOf(Function);
+        handler();
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.get('session_message')).toBe('This is a session message');
+        expect(url.searchParams.get('session_required_identities')).toBe('');
+        expect(url.searchParams.get('session_required_mfa')).toBe('false');
+        expect(url.searchParams.get('session_required_single_domain')).toBe('');
+        expect(url.searchParams.get('prompt')).toBe('login');
+      });
+
+      describe('additionalParameters', () => {
+        it('should preserve passed in query parameters for "authorization_requirements" error', () => {
+          instance.handleErrorResponse(TRANSFER_AUTHORIZATION_REQUIREMENTS_ERROR, {
+            additionalParams: {
+              foo: 'bar',
+            },
+          });
+          const url = new URL(window.location.href);
+          expect(url.searchParams.get('foo')).toBe('bar');
+        });
+
+        it('should preserve passed in query parameters for "ConsentRequired" error', () => {
+          instance.handleErrorResponse(TRANSFER_CONSENT_REQUIRED_ERROR, {
+            additionalParams: {
+              retained_state: 'example-state',
+              retained_route: 'example.route',
+            },
+          });
+          const url = new URL(window.location.href);
+          expect(url.searchParams.get('retained_state')).toBe('example-state');
+          expect(url.searchParams.get('retained_route')).toBe('example.route');
+          expect(url.searchParams.get('scope')).toBe(
+            TRANSFER_CONSENT_REQUIRED_ERROR.required_scopes.join(' '),
+          );
+        });
+      });
     });
   });
-});
+}

--- a/src/core/__tests__/authorization/RedirectTransport.spec.ts
+++ b/src/core/__tests__/authorization/RedirectTransport.spec.ts
@@ -1,14 +1,16 @@
+import { version } from 'node:process';
+
 import '../../../__mocks__/sessionStorage';
 import '../../../__mocks__/window-location';
-import PKCE from 'js-pkce';
 import { RedirectTransport } from '../../authorization/RedirectTransport';
+import { oauth2 } from '../../../services/auth';
 
 const MOCK_CONFIG = {
-  client_id: 'CLIENT_ID',
-  redirect_uri: 'https://redirect_uri/my-page',
+  client: 'CLIENT_ID',
+  redirect: 'https://redirect_uri/my-page',
   authorization_endpoint: 'AUTHORIZATION_ENDPOINT',
   token_endpoint: 'TOKEN_ENDPOINT',
-  requested_scopes: 'REQUIRED_SCOPES',
+  scopes: 'REQUIRED_SCOPES',
 };
 
 const MOCK_TOKEN = {
@@ -16,7 +18,7 @@ const MOCK_TOKEN = {
   expires_in: 12000,
   refresh_expires_in: 12000,
   refresh_token: 'REFRESH_TOKEN',
-  scope: MOCK_CONFIG.requested_scopes,
+  scope: MOCK_CONFIG.scopes,
   token_type: 'Bearer',
 };
 
@@ -25,50 +27,59 @@ describe('RedirectTransport', () => {
     jest.resetAllMocks();
   });
 
-  it('should authorize using the window.location.assign method', async () => {
-    const transport = new RedirectTransport(MOCK_CONFIG);
-    transport.send();
-    expect(window.location.assign).toHaveBeenCalled();
-    expect(window.location.assign).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'AUTHORIZATION_ENDPOINT?response_type=code&client_id=CLIENT_ID&state=&scope=REQUIRED_SCOPES&redirect_uri=https%3A%2F%2Fredirect_uri%2Fmy-page',
-      ),
-    );
-  });
-
-  describe('getToken', () => {
-    it('returns `undefined` when called on location with missing required parameters (code)', async () => {
-      window.location.href = MOCK_CONFIG.redirect_uri;
+  if (version.startsWith('v18')) {
+    it('should error in unsupported environments', () => {
+      expect(() => new RedirectTransport(MOCK_CONFIG)).toThrow(
+        'RedirectTransport is not supported in this environment.',
+      );
+    });
+  } else {
+    it('should authorize using the window.location.assign method', async () => {
       const transport = new RedirectTransport(MOCK_CONFIG);
-      const response = await transport.getToken();
-      expect(response).toBeUndefined();
+      transport.send();
+      expect(window.location.assign).toHaveBeenCalled();
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'AUTHORIZATION_ENDPOINT?response_type=code&client_id=CLIENT_ID&state=&scope=REQUIRED_SCOPES&redirect_uri=https%3A%2F%2Fredirect_uri%2Fmy-page',
+        ),
+      );
     });
 
-    it('removes code and state from location after processing (by default)', async () => {
-      jest
-        .spyOn(PKCE.prototype, 'exchangeForAccessToken')
-        .mockImplementation(async () => MOCK_TOKEN);
+    describe('getToken', () => {
+      it('returns `undefined` when called on location with missing required parameters (code)', async () => {
+        window.location.href = MOCK_CONFIG.redirect;
+        const transport = new RedirectTransport(MOCK_CONFIG);
+        const response = await transport.getToken();
+        expect(response).toBeUndefined();
+      });
 
-      const transport = new RedirectTransport(MOCK_CONFIG);
-      window.location.href = `${MOCK_CONFIG.redirect_uri}?code=CODE&state=SOME_STATE`;
-      const response = await transport.getToken();
-      expect(response).toBe(MOCK_TOKEN);
-      expect(window.location.replace).toHaveBeenCalled();
-      expect(window.location.replace).toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect_uri));
-    });
+      it('removes code and state from location after processing (by default)', async () => {
+        jest
+          .spyOn(oauth2.token, 'token')
+          .mockReturnValue(Promise.resolve(Response.json(MOCK_TOKEN)));
 
-    it('it does not alter the URL if shouldReplace: true is passed', async () => {
-      jest
-        .spyOn(PKCE.prototype, 'exchangeForAccessToken')
-        .mockImplementation(async () => MOCK_TOKEN);
-      const url = `${MOCK_CONFIG.redirect_uri}?code=CODE&state=SOME_STATE`;
-      const transport = new RedirectTransport(MOCK_CONFIG);
-      window.location.href = `${MOCK_CONFIG.redirect_uri}?code=CODE&state=SOME_STATE`;
-      const response = await transport.getToken({ shouldReplace: false });
-      expect(response).toBe(MOCK_TOKEN);
-      expect(window.location.assign).not.toHaveBeenCalled();
-      expect(window.location.assign).not.toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect_uri));
-      expect(window.location.href).toEqual(url);
+        const transport = new RedirectTransport(MOCK_CONFIG);
+        window.location.href = `${MOCK_CONFIG.redirect}?code=CODE&state=SOME_STATE`;
+        const response = await transport.getToken();
+        expect(response).toBe(MOCK_TOKEN);
+        expect(window.location.replace).toHaveBeenCalled();
+        expect(window.location.replace).toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect));
+      });
+
+      it('it does not alter the URL if shouldReplace: true is passed', async () => {
+        jest
+          .spyOn(oauth2.token, 'token')
+          .mockReturnValue(Promise.resolve(Response.json(MOCK_TOKEN)));
+
+        const url = `${MOCK_CONFIG.redirect}?code=CODE&state=SOME_STATE`;
+        const transport = new RedirectTransport(MOCK_CONFIG);
+        window.location.href = `${MOCK_CONFIG.redirect}?code=CODE&state=SOME_STATE`;
+        const response = await transport.getToken({ shouldReplace: false });
+        expect(response).toBe(MOCK_TOKEN);
+        expect(window.location.assign).not.toHaveBeenCalled();
+        expect(window.location.assign).not.toHaveBeenCalledWith(new URL(MOCK_CONFIG.redirect));
+        expect(window.location.href).toEqual(url);
+      });
     });
-  });
+  }
 });

--- a/src/core/authorization/AuthorizationManager.ts
+++ b/src/core/authorization/AuthorizationManager.ts
@@ -311,7 +311,7 @@ export class AuthorizationManager {
     return `${scopes}${this.configuration.useRefreshTokens ? ' offline_access' : ''}`;
   }
 
-  #buildTransport(overrides?: Partial<ConstructorParameters<typeof RedirectTransport>[0]>) {
+  #buildTransport(overrides?: Partial<RedirectTransportOptions>) {
     const scopes = this.#withOfflineAccess(overrides?.scopes ?? (this.configuration.scopes || ''));
 
     return new RedirectTransport({
@@ -320,24 +320,24 @@ export class AuthorizationManager {
       scopes,
       ...overrides,
       // @todo Decide if we want to include the `include_consented_scopes` parameter by default.
-      // params: {
-      //   include_consented_scopes: true,
-      //   ...overrides?.params,
-      // },
+      params: {
+        // include_consented_scopes: true,
+        ...overrides?.params,
+      },
     });
   }
 
   /**
    * Initiate the login process by redirecting to the Globus Auth login page.
    */
-  login(options = { additionalParams: {} }) {
+  async login(options = { additionalParams: {} }) {
     log('debug', 'AuthorizationManager.login');
     this.reset();
     /**
      * In the future, it's possible that we may want to support different types of transports.
      */
     const transport = this.#buildTransport({ params: options?.additionalParams });
-    transport.send();
+    await transport.send();
   }
 
   /**
@@ -371,15 +371,15 @@ export class AuthorizationManager {
    * @param options.execute Whether to execute the handler immediately.
    * @param options.additionalParms Additional query parameters to be included with the transport generated URL.
    */
-  handleErrorResponse(
+  async handleErrorResponse(
     response: Record<string, unknown>,
     options?: { execute?: true; additionalParams?: RedirectTransportOptions['params'] } | true,
-  ): void;
-  handleErrorResponse(
+  ): Promise<void>;
+  async handleErrorResponse(
     response: Record<string, unknown>,
     options?: { execute?: false; additionalParams?: RedirectTransportOptions['params'] } | false,
-  ): () => void;
-  handleErrorResponse(
+  ): Promise<() => Promise<void>>;
+  async handleErrorResponse(
     response: Record<string, unknown>,
     options?:
       | { execute?: boolean; additionalParams?: RedirectTransportOptions['params'] }
@@ -399,34 +399,42 @@ export class AuthorizationManager {
       'debug',
       `AuthorizationManager.handleErrorResponse | response=${JSON.stringify(response)} execute=${opts.execute}`,
     );
-    let handler = () => {};
+    let handler = async () => {};
     if (isAuthorizationRequirementsError(response)) {
       log(
         'debug',
         'AuthorizationManager.handleErrorResponse | error=AuthorizationRequirementsError',
       );
-      handler = () =>
-        this.handleAuthorizationRequirementsError(response, {
+      handler = async () => {
+        await this.handleAuthorizationRequirementsError(response, {
           additionalParams: opts.additionalParams,
         });
+      };
     }
     if (isConsentRequiredError(response)) {
       log('debug', 'AuthorizationManager.handleErrorResponse | error=ConsentRequiredError');
-      handler = () =>
-        this.handleConsentRequiredError(response, { additionalParams: opts.additionalParams });
+      handler = async () => {
+        await this.handleConsentRequiredError(response, {
+          additionalParams: opts.additionalParams,
+        });
+      };
     }
     if ('code' in response && response['code'] === 'AuthenticationFailed') {
       log('debug', 'AuthorizationManager.handleErrorResponse | error=AuthenticationFailed');
-      handler = () => this.revoke();
+      handler = async () => {
+        await this.revoke();
+      };
     }
-    return opts.execute === true ? handler() : handler;
+
+    const returnValue = opts.execute === true ? await handler() : handler;
+    return returnValue;
   }
 
   /**
    * Process a well-formed Authorization Requirements error response from a Globus service
    * and redirect the user to the Globus Auth login page with the necessary parameters.
    */
-  handleAuthorizationRequirementsError(
+  async handleAuthorizationRequirementsError(
     response: AuthorizationRequirementsError,
     options?: { additionalParams?: RedirectTransportOptions['params'] },
   ) {
@@ -437,14 +445,14 @@ export class AuthorizationManager {
         ...options?.additionalParams,
       },
     });
-    this.#transport.send();
+    await this.#transport.send();
   }
 
   /**
    * Process a well-formed `ConsentRequired` error response from a Globus service
    * and redirect the user to the Globus Auth login page with the necessary parameters.
    */
-  handleConsentRequiredError(
+  async handleConsentRequiredError(
     response: ConsentRequiredError,
     options?: { additionalParams?: RedirectTransportOptions['params'] },
   ) {
@@ -454,7 +462,7 @@ export class AuthorizationManager {
         ...options?.additionalParams,
       },
     });
-    this.#transport.send();
+    await this.#transport.send();
   }
 
   /**

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -108,10 +108,13 @@ export class RedirectTransport {
         params.get('error_description') || 'An error occurred during the authorization process.',
       );
     }
+
+    const code = params.get('code');
+
     /**
      * If we don't have a `code` parameter, we can't exchange it for an access token.
      */
-    if (!params.get('code')) return undefined;
+    if (!code) return undefined;
 
     /**
      * Grab the PKCE information from session storage.
@@ -140,7 +143,7 @@ export class RedirectTransport {
      * Prepare the payload for the PKCE token exchange.
      */
     const payload: AuthorizationCodeExchangeParameters = {
-      code: params.get('code')!,
+      code,
       client_id: this.#options.client,
       /**
        * Retrieve the code verifier from session storage.

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -1,6 +1,12 @@
-import PKCE from 'js-pkce';
-import type IConfig from 'js-pkce/dist/IConfig';
-import type IObject from 'js-pkce/dist/IObject';
+import { getAuthorizationEndpoint, oauth2 } from '../../services/auth';
+import type { AuthorizationManagerConfiguration } from './AuthorizationManager';
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+  AuthorizationRequestParameters,
+  AuthorizationCodeExchangeParameters,
+} from './pkce';
 
 export type GetTokenOptions = {
   /**
@@ -10,44 +16,65 @@ export type GetTokenOptions = {
   shouldReplace?: boolean;
 };
 
-export type RedirectTransportOptions = IConfig & {
-  /**
-   * Additional parameters to be included in the query string of the authorization request.
-   */
-  params?: IObject;
+export type RedirectTransportOptions = Pick<
+  AuthorizationManagerConfiguration,
+  'client' | 'redirect' | 'scopes'
+> & {
+  params?: {
+    [key: string]: string;
+  };
 };
 
-/**
- * Resets js-pkce state
- * @see https://github.com/bpedroza/js-pkce/blob/master/src/PKCE.ts
- */
+const KEYS = {
+  PKCE_STATE: 'pkce_state',
+  PKCE_CODE_VERIFIER: 'pkce_code_verifier',
+};
+
 function resetPKCE() {
-  sessionStorage.removeItem('pkce_state');
-  sessionStorage.removeItem('pkce_code_verifier');
+  sessionStorage.removeItem(KEYS.PKCE_STATE);
+  sessionStorage.removeItem(KEYS.PKCE_CODE_VERIFIER);
 }
 
 export class RedirectTransport {
-  #pkce: PKCE;
-
-  #params: RedirectTransportOptions['params'] = {};
+  #options: RedirectTransportOptions;
 
   constructor(options: RedirectTransportOptions) {
-    const { params, ...config } = options;
-    this.#pkce = new PKCE({
-      ...config,
-    });
-    this.#params = {
-      ...params,
-    };
+    this.#options = options;
   }
 
-  send() {
+  /**
+   * For the redirect transport, sending the request will redirect the user to the authorization endpoint, initiating the OAuth flow.
+   */
+  async send() {
     /**
-     * By resetting PKCE before sending, we ensure that a fresh `code_challenge` is generated
-     * when `authorizeUrl` is called.
+     * Since we'll be using PKCE, we need to generate a code verifier and challenge
+     * for the OAuth handshake.
      */
-    resetPKCE();
-    window.location.assign(this.#pkce.authorizeUrl(this.#params));
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    const state = generateState();
+    /**
+     * The verifier and state are stored in session storage so that we can validate
+     * the response when we receive it.
+     */
+    sessionStorage.setItem(KEYS.PKCE_CODE_VERIFIER, verifier);
+    sessionStorage.setItem(KEYS.PKCE_STATE, state);
+
+    const params: AuthorizationRequestParameters = {
+      client_id: this.#options.client,
+      scope: this.#options.scopes || '',
+      redirect_uri: this.#options.redirect,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      response_type: 'code',
+      ...[this.#options.params],
+    };
+
+    const url = new URL(getAuthorizationEndpoint());
+    url.search = new URLSearchParams(params).toString();
+
+    window.location.assign(url);
   }
 
   /**
@@ -58,11 +85,61 @@ export class RedirectTransport {
     const url = new URL(window.location.href);
     const params = new URLSearchParams(url.search);
     /**
+     * Check for an error in the OAuth flow.
+     * @see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+     */
+    if (params.get('error')) {
+      throw new Error(
+        params.get('error_description') || 'An error occurred during the authorization process.',
+      );
+    }
+    /**
      * If we don't have a `code` parameter, we can't exchange it for an access token.
      */
     if (!params.get('code')) return undefined;
-    const response = await this.#pkce.exchangeForAccessToken(url.toString());
+
+    /**
+     * Grab the PKCE information from session storage.
+     */
+    const state = sessionStorage.getItem(KEYS.PKCE_STATE);
+    const verifier = sessionStorage.getItem(KEYS.PKCE_CODE_VERIFIER);
+    /**
+     * Now that we have the values in memory, we can remove them from session storage.
+     */
     resetPKCE();
+    /**
+     * Validate the `state` parameter matches the preserved state (to prevent CSRF attacks).
+     */
+    if (params.get('state') !== state) {
+      throw new Error('Invalid State');
+    }
+    /**
+     * Ensure we have a valid code verifier.
+     */
+    if (!verifier) {
+      throw new Error('Invalid Code Verifier');
+    }
+
+    /**
+     * Prepare the payload for the PKCE token exchange.
+     */
+    const payload: AuthorizationCodeExchangeParameters = {
+      code: params.get('code')!,
+      client_id: this.#options.client,
+      /**
+       * Retrieve the code verifier from session storage.
+       */
+      code_verifier: verifier,
+      redirect_uri: this.#options.redirect,
+      grant_type: 'authorization_code',
+    };
+
+    const response = await (
+      await oauth2.token.exchange({
+        payload,
+      })
+    ).json();
+
     if (options.shouldReplace) {
       /**
        * Remove the `code` and `state` parameters from the URL.

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -6,6 +6,7 @@ import {
   generateState,
   AuthorizationRequestParameters,
   AuthorizationCodeExchangeParameters,
+  isSupported,
 } from './pkce';
 
 export type GetTokenOptions = {
@@ -40,7 +41,12 @@ export class RedirectTransport {
 
   constructor(options: RedirectTransportOptions) {
     this.#options = options;
+    if (RedirectTransport.supported === false) {
+      throw new Error('RedirectTransport is not supported in this environment.');
+    }
   }
+
+  static supported = isSupported();
 
   /**
    * For the redirect transport, sending the request will redirect the user to the authorization endpoint, initiating the OAuth flow.

--- a/src/core/authorization/pkce.ts
+++ b/src/core/authorization/pkce.ts
@@ -17,9 +17,7 @@ const encode = (value: string) =>
 
 async function sha256(input: string) {
   const hashBuffer = await getCrypto().subtle.digest('SHA-256', new TextEncoder().encode(input));
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((item) => item.toString(16).padStart(2, '0'))
-    .join('');
+  return String.fromCharCode(...new Uint8Array(hashBuffer));
 }
 
 /**
@@ -32,13 +30,16 @@ const PKCE_SAFE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0
  * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
  */
 export function generateCodeVerifier() {
+  /**
+   * @todo Make length random between 43 and 128 characters
+   */
   return Array.from(getCrypto().getRandomValues(new Uint8Array(43)))
     .map((v) => PKCE_SAFE_CHARSET[v % PKCE_SAFE_CHARSET.length])
     .join('');
 }
 
 /**
- * Create a Code Challenge from a provided Code Verifier
+ * Create a Code Challenge from a provided Code Verifier (assumes S256 `code_challenge_method`).
  * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.2
  */
 export async function generateCodeChallenge(verifier: string) {
@@ -47,9 +48,7 @@ export async function generateCodeChallenge(verifier: string) {
 }
 
 export function generateState() {
-  return Array.from(getCrypto().getRandomValues(new Uint8Array(16)))
-    .map((v) => v.toString(16).padStart(2, '0'))
-    .join('');
+  return String.fromCharCode(...Array.from(getCrypto().getRandomValues(new Uint8Array(16))));
 }
 
 /**

--- a/src/core/authorization/pkce.ts
+++ b/src/core/authorization/pkce.ts
@@ -1,5 +1,11 @@
-function getCrypto() {
-  return globalThis.crypto;
+export function isSupported() {
+  return 'crypto' in globalThis;
+}
+
+function getCrypto(): Crypto {
+  return 'webcrypto' in globalThis.crypto
+    ? (globalThis.crypto.webcrypto as unknown as Crypto)
+    : globalThis.crypto;
 }
 
 /**

--- a/src/core/authorization/pkce.ts
+++ b/src/core/authorization/pkce.ts
@@ -1,0 +1,72 @@
+function getCrypto() {
+  return globalThis.crypto;
+}
+
+/**
+ * Base64 URL encode a string.
+ * @see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+ */
+const encode = (value: string) =>
+  btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+async function sha256(input: string) {
+  const hashBuffer = await getCrypto().subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((item) => item.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Character set allowed to be used in the PKCE `code_verifier`
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+ */
+const PKCE_SAFE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+/**
+ * Create a Code Verifier for PKCE
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+ */
+export function generateCodeVerifier() {
+  return Array.from(getCrypto().getRandomValues(new Uint8Array(43)))
+    .map((v) => PKCE_SAFE_CHARSET[v % PKCE_SAFE_CHARSET.length])
+    .join('');
+}
+
+/**
+ * Create a Code Challenge from a provided Code Verifier
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.2
+ */
+export async function generateCodeChallenge(verifier: string) {
+  const hashed = await sha256(verifier);
+  return encode(hashed);
+}
+
+export function generateState() {
+  return Array.from(getCrypto().getRandomValues(new Uint8Array(16)))
+    .map((v) => v.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * @see https://www.oauth.com/oauth2-servers/pkce/authorization-code-exchange/
+ */
+export type AuthorizationCodeExchangeParameters = {
+  code: string;
+  code_verifier: string;
+  client_id: string;
+  client_secret?: string;
+  redirect_uri: string;
+  grant_type: 'authorization_code';
+};
+
+/**
+ * @see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+ */
+export type AuthorizationRequestParameters = {
+  client_id: string;
+  redirect_uri: string;
+  response_type: 'code';
+  scope: string;
+  state: string;
+  code_challenge: string;
+  code_challenge_method: 'S256' | 'plain';
+};

--- a/src/core/authorization/pkce.ts
+++ b/src/core/authorization/pkce.ts
@@ -21,10 +21,15 @@ async function sha256(input: string) {
 }
 
 /**
+ * Character set for generating random alpha-numeric strings.
+ */
+const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+/**
  * Character set allowed to be used in the PKCE `code_verifier`
  * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
  */
-const PKCE_SAFE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+const PKCE_SAFE_CHARSET = `${CHARSET}-._~`;
 /**
  * Create a Code Verifier for PKCE
  * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
@@ -48,7 +53,9 @@ export async function generateCodeChallenge(verifier: string) {
 }
 
 export function generateState() {
-  return String.fromCharCode(...Array.from(getCrypto().getRandomValues(new Uint8Array(16))));
+  return Array.from(getCrypto().getRandomValues(new Uint8Array(16)))
+    .map((v) => CHARSET[v % CHARSET.length])
+    .join('');
 }
 
 /**

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -63,7 +63,7 @@ export function build(
     search?: Parameters<typeof stringifyParameters>[0];
   },
   sdkOptions?: SDKOptions,
-) {
+): string {
   let url;
   if (typeof serviceOrConfiguration === 'object') {
     url = new URL(path, serviceOrConfiguration.host);

--- a/src/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
+++ b/src/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`oauth2 introspect 1`] = `
     "token": "abc-def-ghi",
   },
   "headers": {
-    "accept": "*/*",
+    "accept": "application/json",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
     "content-length": "53",
@@ -28,7 +28,7 @@ exports[`oauth2 refresh 1`] = `
     "refresh_token": "abc-def-ghi",
   },
   "headers": {
-    "accept": "*/*",
+    "accept": "application/json",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
     "content-length": "75",
@@ -48,7 +48,7 @@ exports[`oauth2 revoke 1`] = `
     "token": "abc-def-ghi",
   },
   "headers": {
-    "accept": "*/*",
+    "accept": "application/json",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
     "content-length": "42",
@@ -83,7 +83,7 @@ exports[`oauth2 validate 1`] = `
     "token": "abc-def-ghi",
   },
   "headers": {
-    "accept": "*/*",
+    "accept": "application/json",
     "accept-encoding": "gzip,deflate",
     "connection": "close",
     "content-length": "40",

--- a/src/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
+++ b/src/services/auth/__tests__/__snapshots__/oauth2.spec.ts.snap
@@ -61,6 +61,29 @@ exports[`oauth2 revoke 1`] = `
 }
 `;
 
+exports[`oauth2 token 1`] = `
+{
+  "formData": {
+    "client_id": "my-client-id",
+    "code": "CODE",
+    "code_verifier": "CODE_VERIFIER",
+    "grant_type": "authorization_code",
+    "redirect_uri": "https://redirect-uri",
+  },
+  "headers": {
+    "accept": "application/json",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "content-length": "130",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+    "host": "auth.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "POST",
+  "url": "https://auth.globus.org/v2/oauth2/token",
+}
+`;
+
 exports[`oauth2 userinfo 1`] = `
 {
   "formData": {},

--- a/src/services/auth/__tests__/oauth2.spec.ts
+++ b/src/services/auth/__tests__/oauth2.spec.ts
@@ -66,6 +66,32 @@ describe('oauth2', () => {
     }).toMatchSnapshot();
   });
 
+  test('token', async () => {
+    const {
+      req: { url, method, headers, formData },
+    } = await mirror(
+      await oauth2.token.token({
+        payload: {
+          grant_type: 'authorization_code',
+          code: 'CODE',
+          client_id: 'my-client-id',
+          code_verifier: 'CODE_VERIFIER',
+          redirect_uri: 'https://redirect-uri',
+        },
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+      formData,
+    }).toMatchSnapshot();
+  });
+
+  test('exchange (alias)', () => {
+    expect(oauth2.token.exchange).toBe(oauth2.token.token);
+  });
+
   test('refresh', async () => {
     expect(() => {
       // @ts-expect-error This intentionally does not have a payload to test the error case.


### PR DESCRIPTION
The js-pkce package has presented a few problems for our usage:

1. It is currently bundled to CommonJS _and_ uses a default export, which causes issues with our ESM build.
2. The code is transpiled to ES5, which is outdated for our target support.
3. There are many outdated dependencies; It's use of crypto-js stands out the most, since `crypto` and `crypto.webcrypto` are native in most modern browsers and Node runtimes.

This PR drops the js-pkce package and updates our implementation of PKCE to use native methods where possible.