### PR TITLE
fix(Authorization): ensure caller-provided "state" is stored on OAuth dispatch

### DIFF
--- a/src/core/__tests__/authorization/RedirectTransport.spec.ts
+++ b/src/core/__tests__/authorization/RedirectTransport.spec.ts
@@ -45,6 +45,26 @@ describe('RedirectTransport', () => {
       );
     });
 
+    it('should accept caller-provided "state"', async () => {
+      const transport = new RedirectTransport({
+        ...MOCK_CONFIG,
+        params: {
+          state: 'CUSTOM_STATE',
+        },
+      });
+      await transport.send();
+      expect(window.location.assign).toHaveBeenCalled();
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://auth.globus.org/v2/oauth2/authorize?response_type=code&client_id=CLIENT_ID&scope=REQUIRED_SCOPES&redirect_uri=https%3A%2F%2Fredirect_uri%2Fmy-page&state=CUSTOM_STATE',
+        ),
+      );
+      /**
+       * Ensure that the state is stored in sessionStorage.
+       */
+      expect(sessionStorage.getItem(KEYS.PKCE_STATE)).toBe('CUSTOM_STATE');
+    });
+
     describe('getToken', () => {
       it('returns `undefined` when called on location with missing required parameters (code)', async () => {
         window.location.href = MOCK_CONFIG.redirect;

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -68,7 +68,10 @@ export class RedirectTransport {
      */
     const verifier = generateCodeVerifier();
     const challenge = await generateCodeChallenge(verifier);
-    const state = generateState();
+    /**
+     * If there is caller-provided `state`, use it; Otherwise, generate a state parameter.
+     */
+    const state = this.#options.params?.['state'] ?? generateState();
     /**
      * The verifier and state are stored in session storage so that we can validate
      * the response when we receive it.
@@ -131,7 +134,9 @@ export class RedirectTransport {
      * Validate the `state` parameter matches the preserved state (to prevent CSRF attacks).
      */
     if (params.get('state') !== state) {
-      throw new Error('Invalid State');
+      throw new Error(
+        'Invalid State. The received "state" parameter does not match the expected state.',
+      );
     }
     /**
      * Ensure we have a valid code verifier.


### PR DESCRIPTION
This will ensure the value in sessionStorage represents the caller-provided value.

Relates to #318