### PR TITLE
fix(Search, Typescript): updates the `gmeta` property in `GSearchResult` type

### DIFF
--- a/src/services/search/service/query.ts
+++ b/src/services/search/service/query.ts
@@ -40,7 +40,7 @@ export type GBucket = {
  * @see https://docs.globus.org/api/search/reference/post_query/#gsearchresult
  */
 export type GSearchResult = {
-  gmeta: GMetaResult;
+  gmeta: GMetaResult[];
   facet_results?: GFacetResult[];
   offset: number;
   count: number;


### PR DESCRIPTION
- `gmeta` is an array of `GMetaResult` (https://docs.globus.org/api/search/reference/post_query/#gsearchresult)