### PR TITLE
feat(Auth): Adds `auth.identities.consents.getAll` service method.

### DIFF
--- a/src/services/auth/__tests__/identities.spec.ts
+++ b/src/services/auth/__tests__/identities.spec.ts
@@ -1,12 +1,12 @@
 import { identities } from '..';
 
-import type { MirroredRequest } from '../../../__mocks__/handlers';
+import { mirror } from '../../../__mocks__/handlers';
 
 test('get', async () => {
   const result = await identities.get('6521a0c3-ffc9-4432-9cb6-41fa8fe2e4e9');
   const {
     req: { url, method, headers },
-  } = (await result.json()) as unknown as MirroredRequest;
+  } = await mirror(result);
 
   expect({
     url,
@@ -35,7 +35,7 @@ test('getAll', async () => {
   });
   const {
     req: { url, method, headers },
-  } = (await result.json()) as unknown as MirroredRequest;
+  } = await mirror(result);
 
   expect({
     url,
@@ -65,7 +65,7 @@ test("getAll – with 'include'", async () => {
   });
   const {
     req: { url, method, headers },
-  } = (await result.json()) as unknown as MirroredRequest;
+  } = await mirror(result);
 
   expect({
     url,
@@ -82,6 +82,31 @@ test("getAll – with 'include'", async () => {
   },
   "method": "GET",
   "url": "https://auth.globus.org/identities?ids=538e096f-0468-4d54-8463-50af72c01f95%2C1e1cac10-b303-48d8-aa81-3b3a592a2564&include=identity_provider",
+}
+`);
+});
+
+test('consents', async () => {
+  const result = await identities.consents.getAll('6521a0c3-ffc9-4432-9cb6-41fa8fe2e4e9');
+  const {
+    req: { url, method, headers },
+  } = await mirror(result);
+
+  expect({
+    url,
+    method,
+    headers,
+  }).toMatchInlineSnapshot(`
+{
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip,deflate",
+    "connection": "close",
+    "host": "auth.globus.org",
+    "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+  },
+  "method": "GET",
+  "url": "https://auth.globus.org/identities/6521a0c3-ffc9-4432-9cb6-41fa8fe2e4e9/consents",
 }
 `);
 });

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -38,7 +38,7 @@ export function getTokenEndpoint() {
   return build(AUTH.ID, '/v2/oauth2/token');
 }
 
-export * as identities from './service/identities.js';
+export * as identities from './service/identities/index.js';
 export * as oauth2 from './service/oauth2/index.js';
 
 export function isToken(check: unknown): check is Token {

--- a/src/services/auth/service/identities/consents.ts
+++ b/src/services/auth/service/identities/consents.ts
@@ -1,0 +1,39 @@
+import { ID, SCOPES } from '../../config.js';
+import { serviceRequest } from '../../../../services/shared.js';
+
+import type { JSONFetchResponse, ServiceMethodDynamicSegments } from '../../../types.js';
+
+export type Consent = {
+  auto_approved: boolean;
+  effective_identity: string;
+  id: number;
+  client: string;
+  updated: string;
+  /**
+   * An array of `Consent.id` values that represents the location of this consent in the dependency graph.
+   */
+  dependency_path: number[];
+  status: string;
+  allows_refresh: boolean;
+  scope_name: string;
+  created: string;
+  atomically_revocable: boolean;
+  scope: string;
+  last_used: string;
+};
+
+export const getAll = function (
+  identity_id,
+  options = {},
+  sdkOptions?,
+): Promise<JSONFetchResponse<{ consents: Consent[] }>> {
+  return serviceRequest(
+    {
+      service: ID,
+      scope: SCOPES.VIEW_IDENTITIES,
+      path: `/identities/${identity_id}/consents`,
+    },
+    options,
+    sdkOptions,
+  );
+} satisfies ServiceMethodDynamicSegments<string, Record<string, any>>;

--- a/src/services/auth/service/identities/index.ts
+++ b/src/services/auth/service/identities/index.ts
@@ -1,7 +1,9 @@
-import { ID, SCOPES } from '../config.js';
-import { serviceRequest } from '../../../services/shared.js';
+import { ID, SCOPES } from '../../config.js';
+import { serviceRequest } from '../../../../services/shared.js';
 
-import type { ServiceMethod, ServiceMethodDynamicSegments } from '../../types.js';
+import type { ServiceMethod, ServiceMethodDynamicSegments } from '../../../types.js';
+
+export * as consents from './consents.js';
 
 /**
  * Fetch a single Identity by ID.


### PR DESCRIPTION
chore(Auth): Updates the `auth.identities` direct import path to `@globus/sdk/services/auth/identities/index.js`
chore(Auth, Typescript): adds `Consent` type.