### PR TITLE
feat(Auth): adds Globus Auth `utils`, including `auth.utils.hasConsentForScope`

### DIFF
--- a/src/services/auth/__tests__/utils.spec.ts
+++ b/src/services/auth/__tests__/utils.spec.ts
@@ -1,0 +1,305 @@
+import { Consent } from '../service/identities/consents';
+import { toScopeTree, hasConsentForScope } from '../utils';
+
+describe('toScopeTree', () => {
+  it('should parse a single scope without children', () => {
+    const scope = 'urn:globus:auth:scope:transfer.api.globus.org:all';
+    const result = toScopeTree(scope);
+    expect(result).toEqual([
+      {
+        scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+        atomically_revocable: false,
+        children: [],
+      },
+    ]);
+  });
+
+  it('should parse a single scope with children', () => {
+    const scope =
+      'urn:globus:auth:scope:transfer.api.globus.org:all[https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access]';
+    const result = toScopeTree(scope);
+    expect(result).toEqual([
+      {
+        scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+        atomically_revocable: false,
+        children: [
+          {
+            scope:
+              'https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access',
+            atomically_revocable: false,
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should parse a dependent scope with atomically revocable flag', () => {
+    const scope =
+      'urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access]';
+    const result = toScopeTree(scope);
+    expect(result).toEqual([
+      {
+        scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+        atomically_revocable: false,
+        children: [
+          {
+            scope:
+              'https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access',
+            atomically_revocable: true,
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should parse a complex scope with nested children and atomically revocable flag', () => {
+    const scope =
+      'urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access[https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/ls]] urn:globus:auth:scope:flows.api.globus.org:all';
+    const result = toScopeTree(scope);
+
+    expect(result).toEqual([
+      {
+        scope: 'urn:globus:auth:scope:transfer.api.globus.org:all',
+        atomically_revocable: false,
+        children: [
+          {
+            scope:
+              'https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access',
+            atomically_revocable: true,
+            children: [
+              {
+                scope: 'https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/ls',
+                atomically_revocable: false,
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        scope: 'urn:globus:auth:scope:flows.api.globus.org:all',
+        atomically_revocable: false,
+        children: [],
+      },
+    ]);
+  });
+});
+
+describe('hasConsentForScope', () => {
+  const SINGLE_DEP: Consent[] = [
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T02:29:34.425920+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554],
+      status: 'approved',
+      id: 485554,
+      scope_name: 'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: 'a8906c25-7b22-4d87-8245-ebe58fd4df53',
+      client: '89ba3e72-768f-4ddb-952d-e0bb7305e2c7',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485555],
+      status: 'approved',
+      id: 485555,
+      scope_name: 'urn:globus:auth:scope:auth.globus.org:view_identities',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4917e759-f300-40a8-a95e-5fce507f9857',
+      client: '744574bb-57fb-4553-88a9-9d84bcd66eb2',
+    },
+  ];
+
+  const MULTI_DEP: Consent[] = [
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T02:29:34.425920+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554],
+      status: 'approved',
+      id: 485554,
+      scope_name: 'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: 'a8906c25-7b22-4d87-8245-ebe58fd4df53',
+      client: '89ba3e72-768f-4ddb-952d-e0bb7305e2c7',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485555],
+      status: 'approved',
+      id: 485555,
+      scope_name: 'urn:globus:auth:scope:auth.globus.org:view_identities',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4917e759-f300-40a8-a95e-5fce507f9857',
+      client: '744574bb-57fb-4553-88a9-9d84bcd66eb2',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485556],
+      status: 'approved',
+      id: 485556,
+      scope_name: 'urn:globus:auth:scope:auth.globus.org:manage_projects',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4917e759-f300-40a8-a95e-5fce507f9857',
+      client: '744574bb-57fb-4553-88a9-9d84bcd66eb2',
+    },
+  ];
+
+  it('returns "true" for a top-level scope (with dependent scopes)', () => {
+    const result = hasConsentForScope(
+      SINGLE_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections',
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns "false" for a dependent scope, queried as a top-level scope', () => {
+    const result = hasConsentForScope(
+      SINGLE_DEP,
+      'urn:globus:auth:scope:auth.globus.org:view_identities',
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns "false" for a dependent scope, queried as a top-level scope (space seperated)', () => {
+    const result = hasConsentForScope(
+      SINGLE_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections urn:globus:auth:scope:auth.globus.org:view_identities',
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns "true" for a dependent scope', () => {
+    const result = hasConsentForScope(
+      SINGLE_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections[urn:globus:auth:scope:auth.globus.org:view_identities]',
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns "false" for a missing dependent scope', () => {
+    const result = hasConsentForScope(
+      SINGLE_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections[urn:globus:auth:scope:auth.globus.org:data_access]',
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns "true" for multiple unique dependent scopes', () => {
+    const result = hasConsentForScope(
+      MULTI_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections[urn:globus:auth:scope:auth.globus.org:view_identities] urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections[urn:globus:auth:scope:auth.globus.org:manage_projects]',
+    );
+    expect(result).toBe(true);
+  });
+
+  const DEEP_MULTI_DEP: Consent[] = [
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T02:29:34.425920+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554],
+      status: 'approved',
+      id: 485554,
+      scope_name: 'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: 'a8906c25-7b22-4d87-8245-ebe58fd4df53',
+      client: '89ba3e72-768f-4ddb-952d-e0bb7305e2c7',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485555],
+      status: 'approved',
+      id: 485555,
+      scope_name: 'urn:globus:auth:scope:auth.globus.org:view_identities',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4917e759-f300-40a8-a95e-5fce507f9857',
+      client: '744574bb-57fb-4553-88a9-9d84bcd66eb2',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485560],
+      status: 'approved',
+      id: 485560,
+      scope_name: 'urn:globus:auth:scope:transfer.api.globus.org:set_gcs_attributes',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4f77b5e6-270c-4d00-b2da-8f9f415ade05',
+      client: '744574bb-57fb-4553-88a9-9d84bcd66eb2',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485560, 485561],
+      status: 'approved',
+      id: 485561,
+      scope_name: 'urn:globus:auth:scope:auth.globus.org:view_identities',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: '4917e759-f300-40a8-a95e-5fce507f9857',
+      client: 'cf01eb30-9884-11e5-8d77-87f1f8b059db',
+    },
+    {
+      auto_approved: false,
+      atomically_revocable: false,
+      updated: '2025-01-08T00:42:08.406080+00:00',
+      last_used: '2025-01-08T00:42:08.406080+00:00',
+      created: '2025-01-08T00:42:08.406080+00:00',
+      dependency_path: [485554, 485560, 485562],
+      status: 'approved',
+      id: 485562,
+      scope_name: 'urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships',
+      effective_identity: '70ecdb3e-b77a-4e09-af36-4f00fdcaa2dc',
+      allows_refresh: false,
+      scope: 'a9c7ef6f-3858-40fc-a238-551fcef1e7ef',
+      client: 'cf01eb30-9884-11e5-8d77-87f1f8b059db',
+    },
+  ];
+
+  it('handles deeply nested dependent scopes', () => {
+    const result = hasConsentForScope(
+      DEEP_MULTI_DEP,
+      'urn:globus:auth:scope:744574bb-57fb-4553-88a9-9d84bcd66eb2:manage_collections[urn:globus:auth:scope:transfer.api.globus.org:set_gcs_attributes[urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships]]',
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/services/auth/__tests__/utils.spec.ts
+++ b/src/services/auth/__tests__/utils.spec.ts
@@ -104,7 +104,7 @@ describe('toScopeTree', () => {
     ]);
   });
 
-  it.only('should parse a complex scope with nested space-seperated, atomically revocable, dependent scopes', () => {
+  it('should parse a complex scope with nested space-seperated, atomically revocable, dependent scopes', () => {
     const scope =
       'urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/gcs-endpoint-001/data_access[https://auth.globus.org/scopes/gcs-endpoint-001/ls] *https://auth.globus.org/scopes/gcs-endpoint-002/data_access] urn:globus:auth:scope:flows.api.globus.org:all';
     const result = toScopeTree(scope);

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -55,3 +55,5 @@ export function isGlobusAuthTokenResponse(check: unknown): check is TokenRespons
    */
   return isToken(check) && check !== null && 'resource_server' in check;
 }
+
+export * as utils from './utils.js';

--- a/src/services/auth/utils.ts
+++ b/src/services/auth/utils.ts
@@ -1,0 +1,112 @@
+import { Consent } from './service/identities/consents';
+
+export type ScopeTreeLeaf = {
+  scope: string;
+  atomically_revocable: boolean;
+  children: ScopeTreeLeaf[];
+};
+/**
+ * Parses a scope string into a normalized structure (leaf) for easier comparison.
+ */
+function parseScope(s: string): ScopeTreeLeaf {
+  let parsedScope = s;
+  const revocable = parsedScope.startsWith('*');
+  if (revocable) {
+    parsedScope = parsedScope.replace(/^\*\s*/, '');
+  }
+  let children: ScopeTreeLeaf[] = [];
+  /**
+   * If there is no bracket, then there are no children and we can return the parsed scope.
+   */
+  const firstBracket = parsedScope.indexOf('[');
+  if (firstBracket === -1) {
+    return {
+      scope: parsedScope,
+      atomically_revocable: revocable,
+      children: [],
+    };
+  }
+  /**
+   * The top-level scope is everything before the first encountered bracket.
+   */
+  const topLevelScope = parsedScope.slice(0, firstBracket);
+  /**
+   * The children are everything inside the brackets.
+   */
+  children = parsedScope
+    .slice(firstBracket + 1, -1)
+    .split(' ')
+    .map(parseScope);
+  return {
+    scope: topLevelScope,
+    atomically_revocable: revocable,
+    children,
+  };
+}
+
+/**
+ * Converts a scope string into a tree structure for easier comparison.
+ */
+export function toScopeTree(scope: string): ScopeTreeLeaf[] {
+  const scopes = scope.split(' ');
+  return scopes.map(parseScope);
+}
+
+/**
+ * Given a list of consent entries and a scope string, determine if **all** scopes have been approved.
+ *
+ * @param consents An array of consent entries (sourced from the Globus Auth API) that will be used as the "haystack" for the search.
+ * @param scope A full scope string that will be parsed into a tree, and compared against the `consents`.
+ * @returns boolean
+ */
+export function hasConsentForScope(consents: Consent[], scope: string): boolean {
+  const tree = toScopeTree(scope);
+  /**
+   * Determine if a leaf of the scope tree has a consent entry (including all `children`).
+   * @param leaf The leaf of the scope tree we are checking for consent.
+   * @param path The current, expected path to the leaf when processing `children`.
+   * @returns boolean
+   */
+  function hasConsentEntry(leaf: ScopeTreeLeaf, path?: number[]): boolean {
+    /**
+     * Find the consent entry that matches the current leaf, and the current path.
+     */
+    const entry = consents.find(
+      (c) =>
+        c.scope_name === leaf.scope &&
+        /**
+         * If a `path` is provided, we need to make sure the entry is at the proper depth.
+         */
+        (path
+          ? c.dependency_path.join(',') === [...path, c.id].join(',')
+          : /**
+             * If there is no `path`, then the entry must be a "top-level" scope.
+             */
+            c.dependency_path.length === 1),
+    );
+    /**
+     * If no entry was found, then the scope has not be explicitly approved (or denied).
+     */
+    if (!entry) return false;
+    /**
+     * If we found an entry, and there are no `children` to process on the leaf,
+     * then we can use the `status` of the entry to determine if the scope has been approved.
+     */
+    if (!leaf.children.length) return entry.status === 'approved';
+    /**
+     * If there are `children` to process, then we need to check if all `children` have been approved.
+     */
+    return leaf.children.every((s) =>
+      hasConsentEntry(
+        s,
+        /**
+         * If there is a `path`, make sure to pass it down to account for deeply nested scopes, otherwise
+         * the `entry` can be considered to "root".
+         */
+        path ? [...path, entry.id] : [entry.id],
+      ),
+    );
+  }
+
+  return tree.every((l) => hasConsentEntry(l));
+}


### PR DESCRIPTION
- Adds `ScopeTreeLeaf` type.

### Adds `toScopeTree`

This method will take a scope string and convert it into an array of `ScopeTreeLeaf`s for processing.

### Example
```js
toScopeTree('urn:globus:auth:scope:transfer.api.globus.org:all');
```
```json
[
  {
    "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
    "atomically_revocable": false,
    "children": []
  }
]
```

```js
toScopeTree('urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access[https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/ls]] urn:globus:auth:scope:flows.api.globus.org:all');
```
```json
[
  {
    "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
    "atomically_revocable": false,
    "children": [
      {
        "scope": "https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access",
        "atomically_revocable": true,
        "children": [
          {
            "scope": "https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/ls",
            "atomically_revocable": false,
            "children": []
          }
        ]
      }
    ]
  },
  {
    "scope": "urn:globus:auth:scope:flows.api.globus.org:all",
    "atomically_revocable": false,
    "children": []
  }
]
```

### Adds `hasConsentForScope`

This method will take an array of `Consent` objects (returned from Globus Auth) and a scope string and determine if **all** of the scopes defined in the `scope` have an `status === 'approved`

Internally, this will convert the provided `scope` string to a tree and recursively do lookups on the provided `consents`.



  