### PR TITLE
fix(Typescript, Search): Improve the GFacet Search type

### DIFF
--- a/src/services/search/service/query.ts
+++ b/src/services/search/service/query.ts
@@ -162,11 +162,12 @@ type HistogramRange = { low: number | string; high: number | string };
  * @see https://docs.globus.org/api/search/reference/post_query/#gfacet
  */
 export type GFacet = {
-  name: string;
+  name?: string;
   field_name: string;
 } & (
   | {
       type: 'terms';
+      size?: number;
     }
   | {
       type: 'sum' | 'avg';
@@ -180,7 +181,6 @@ export type GFacet = {
   | {
       type: 'numeric_histogram';
       size: string;
-      interval: number;
       histogram_range: HistogramRange;
     }
 );


### PR DESCRIPTION
This _seems_ like a more accurate representation of https://docs.globus.org/api/search/reference/post_query/#gfacet...

I was specifically encountering an issue with `size` not being allowed (optional) when using `type: "terms"`. 