### PR TITLE
feat(Typescript): Use internal, OpenAPI-generated, types for Compute, GCS, Groups, and Timer.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,13 +27,14 @@
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "29.7.0",
         "msw": "^2.4.1",
+        "openapi-typescript": "^7.6.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "tslib": "^2.7.0",
         "typedoc": "^0.27.2",
-        "typescript": "^5.5.4"
+        "typescript": "^5.7.3"
       },
       "engines": {
         "node": ">=18"
@@ -1826,6 +1827,102 @@
         "node": ">=18"
       }
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.21.0.tgz",
+      "integrity": "sha512-JBtrrjBIURTnzb7KUIWOF46vSgpfC3rO6Mm8LjtRjtTNCLTyB+mOuU7HrTkVcvUCEBuSuzkivlTHMWT4JETz9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.31.2.tgz",
+      "integrity": "sha512-HScpiSuluLic9+QpsI2JWaegeDuRn3hximPBpiUpy4WdXf74Ev094kpUgjhiD3xDuP/KpVdchooAkLnzQ0X+vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.2",
+        "@redocly/config": "^0.21.0",
+        "colorette": "^1.2.0",
+        "https-proxy-agent": "^7.0.5",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^5.0.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.0.tgz",
@@ -2484,6 +2581,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2507,6 +2614,16 @@
       "dev": true,
       "dependencies": {
         "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -3197,6 +3314,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -3308,6 +3432,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -4813,6 +4944,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4882,6 +5027,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -5921,6 +6079,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6533,6 +6701,71 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.6.1.tgz",
+      "integrity": "sha512-F7RXEeo/heF3O9lOXo2bNjCOtfp7u+D6W3a3VNEH2xE6v+fxLtn5nq0uvUcA1F5aT+CMhNeC5Uqtg5tlXFX/ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.28.0",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.1.0",
+        "supports-color": "^9.4.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/parse-json": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/type-fest": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -6776,6 +7009,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -7948,6 +8191,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8041,6 +8285,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -8318,6 +8569,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "build": "tsc --project tsconfig.package.json && node scripts/build.js",
     "watch": "tsc --watch tsconfig.package.json",
     "generate:docs": "npx typedoc --tsconfig tsconfig.package.json",
+    "generate:types": "node ./scripts/open-api/generate-types.mjs",
     "publish-to-npm": "npm run build && npm publish --access public",
     "publish-to-npm:next": "npm run build && npm publish --access public --tag next"
   },
@@ -105,13 +106,14 @@
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "29.7.0",
     "msw": "^2.4.1",
+    "openapi-typescript": "^7.6.1",
     "prettier": "^3.3.3",
     "serve": "^14.2.3",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tslib": "^2.7.0",
     "typedoc": "^0.27.2",
-    "typescript": "^5.5.4"
+    "typescript": "^5.7.3"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/open-api/generate-types.mjs
+++ b/scripts/open-api/generate-types.mjs
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import openapiTS, { astToString } from 'openapi-typescript';
+
+const OPEN_API_TYPES_DIR = path.resolve(import.meta.dirname, '../../src/open-api/types');
+
+const SCHEMAS = [
+  {
+    url: 'https://groups.api.globus.org/openapi.json',
+    filename: path.join(OPEN_API_TYPES_DIR, `groups.d.ts`),
+  },
+  {
+    url: 'https://timer.automate.globus.org/openapi.json',
+    filename: path.join(OPEN_API_TYPES_DIR, `timer.d.ts`),
+  },
+  {
+    url: 'https://api2.funcx.org/openapi.json',
+    filename: path.join(OPEN_API_TYPES_DIR, `compute.d.ts`),
+  },
+  {
+    url: 'https://docs.globus.org/globus-connect-server/v5.4/api/api.js',
+    filename: path.join(OPEN_API_TYPES_DIR, `gcs/v5.4.d.ts`),
+  },
+];
+
+function generate() {
+  SCHEMAS.forEach(async (schema) => {
+    const ast = await openapiTS(new URL(schema.url), {
+      emptyObjectsUnknown: true,
+    });
+    const contents = astToString(ast);
+    fs.writeFileSync(schema.filename, contents);
+  });
+}
+
+generate();

--- a/src/open-api/types/compute.d.ts
+++ b/src/open-api/types/compute.d.ts
@@ -1,0 +1,3595 @@
+export interface paths {
+    "/v2/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Version
+         * @description Get the version of the API and other services.
+         */
+        get: operations["get_version_v2_version_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        /**
+         * Get Version
+         * @description Get the version of the API and other services.
+         */
+        head: operations["get_version_v2_version_head"];
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/authenticate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Check Authentication
+         * @description Check if the user is authenticated.
+         */
+        get: operations["check_authentication_v2_authenticate_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Funcx Stats
+         * @description Get various usage stats.
+         */
+        get: operations["get_funcx_stats_v2_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/get_amqp_result_connection_url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get User Specific Result Amqp Url
+         * @description Generate new credentials (in the form of a connection URL) for connecting to
+         *     the AMQP service.  A new password is generated afresh every invocation, but
+         *     the existing RMQ user, if any, is not deleted -- any existing connections will
+         *     not be dropped.  The RMQ user will have the vhost permissions set to only be
+         *     allowed to read from queues with names prefixed by the ``user_uuid``.
+         */
+        get: operations["get_user_specific_result_amqp_url_v2_get_amqp_result_connection_url_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/batch_status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Batch Status
+         * @description Get the status of one or more tasks.
+         *
+         *     The body of a request contains a list one or more task IDs; the response
+         *     will contain a dictionary of objects with a set of relevant data for
+         *     each passed ID.
+         */
+        post: operations["get_batch_status_v2_batch_status_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Batch
+         * @description Entry point for submitting tasks to Globus Compute Endpoints
+         *
+         *     This route takes a list of tasks (specified as a tuple of a function id, an
+         *     endpoint id, and a serialized string of arguments to that function); for each
+         *     task, it will generate an AMQP packet with the task information, and route it
+         *     to the endpoint-appropriate AMQP queue.  This route will then return a list
+         *     of task ids that may be utilized to track each task's progress.
+         *
+         *     Crucially, the order of the task id list returned corresponds to the order of
+         *     the tasks submitted to this route.  In pseudo-code,
+         *     `ids[0]`&nbsp;&rArr;&nbsp;`tasks[0]`, `ids[1]`&nbsp;&rArr;&nbsp;`tasks[1]`, ...,
+         *     `ids[N]`&nbsp;&rArr;&nbsp;`tasks[N]`.
+         */
+        post: operations["submit_batch_v2_submit_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register Container
+         * @description Register a new container
+         */
+        post: operations["register_container_v2_containers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/containers/build": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Build Container
+         * @description Build a new container
+         */
+        post: operations["build_container_v2_containers_build_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/containers/build/{container_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Container Build Status
+         * @description Get the status of a container build
+         */
+        get: operations["get_container_build_status_v2_containers_build__container_uuid__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/containers/{container_uuid}/{container_type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Container Status
+         * @description Get the details of a container
+         */
+        get: operations["get_container_status_v2_containers__container_uuid___container_type__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Endpoints
+         * @description Get a list of endpoints associated with the authenticated user.
+         */
+        get: operations["get_endpoints_v2_endpoints_get"];
+        put?: never;
+        /**
+         * Register Endpoint
+         * @description Register an endpoint by associating it with the authenticated user and
+         *     saving it to the database.
+         */
+        post: operations["register_endpoint_v2_endpoints_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/endpoints/{endpoint_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Endpoint
+         * @description Retrieve the metadata for a given endpoint.
+         */
+        get: operations["get_endpoint_v2_endpoints__endpoint_uuid__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Endpoint
+         * @description Delete the endpoint.
+         */
+        delete: operations["delete_endpoint_v2_endpoints__endpoint_uuid__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/endpoints/{endpoint_uuid}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Endpoint Status
+         * @description Get the status of an endpoint.
+         */
+        get: operations["get_endpoint_status_v2_endpoints__endpoint_uuid__status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/endpoints/{endpoint_uuid}/lock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Lock Endpoint
+         * @description Add a temporary lock to the endpoint to block registration requests
+         *     and deletes the current RabbitMQ user/session such that existing
+         *     endpoints, local or remote, shuts down upon losing credentials
+         *
+         *     The POST body is ignored, as the URL and token contain the necessary info.
+         */
+        post: operations["lock_endpoint_v2_endpoints__endpoint_uuid__lock_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/functions/{function_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Function
+         * @description Get information about a registered function by providing it's UUID.
+         */
+        get: operations["get_function_v2_functions__function_uuid__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Function
+         * @description Delete a function.
+         */
+        delete: operations["delete_function_v2_functions__function_uuid__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/functions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register Function
+         * @description Register a function.
+         */
+        post: operations["register_function_v2_functions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/tasks/{task_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Task Status And Result
+         * @description Check the status of a task.
+         */
+        get: operations["get_task_status_and_result_v2_tasks__task_uuid__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/taskgroup/{task_group_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Task Group Tasks
+         * @description Retrieve all task UUIDs associated with a Task Group
+         */
+        get: operations["get_task_group_tasks_v2_taskgroup__task_group_uuid__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register Endpoint
+         * @description Register a new endpoint
+         */
+        post: operations["register_endpoint_v3_endpoints_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints/{endpoint_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Endpoint
+         * @description Check immutable flags against existing endpoint
+         */
+        put: operations["update_endpoint_v3_endpoints__endpoint_uuid__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints/{endpoint_uuid}/lock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Lock Endpoint
+         * @description Temporarily block registration requests for the endpoint.
+         *
+         *     The current AMQP user is also deleted, dropping any open connection.
+         */
+        post: operations["lock_endpoint_v3_endpoints__endpoint_uuid__lock_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints/{endpoint_uuid}/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Batch
+         * @description Entry point for submitting tasks to a Globus Compute Endpoint
+         *
+         *     This route takes a dictionary of function ids mapped to a list of serialized
+         *     arguments destined for invocation at request&#8209;specified (single) endpoint.
+         *     The returned data structure is similar, containing a mapping of the requested
+         *     function ids to the associated list of task ids.  Of note is that the order of
+         *     the returned task ids associated with each function id _is the same order_ as
+         *     specified in the request.
+         *
+         *     The `task_group_id` may be optionally specified if a set of tasks should be
+         *     associated with a Task Group that was created in a previous interaction.
+         *     However, if set and no task group already exists, the route will return an
+         *     HTTP 404.
+         */
+        post: operations["submit_batch_v3_endpoints__endpoint_uuid__submit_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints/{endpoint_uuid}/allowed_functions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Endpoint Allowlist
+         * @description Retrieve the UUIDs of the functions allowed to run on this endpoint
+         */
+        get: operations["get_endpoint_allowlist_v3_endpoints__endpoint_uuid__allowed_functions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/endpoints/{endpoint_uuid}/console": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Endpoint Console Info
+         * @description Get operational information about a running multi-user endpoint.
+         *
+         *     This route can only be accessed by the owner of the multi-user endpoint,
+         *     which must have an associated Globus subscription.
+         */
+        get: operations["get_endpoint_console_info_v3_endpoints__endpoint_uuid__console_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /**
+         * AllowedFunctionsResponse
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "restricted": true,
+         *       "functions": [
+         *         "063a3a9d-f40e-4b46-950a-fb24f75a345c",
+         *         "e4b534c3-d9d0-47b0-8334-f52932ad3d9a",
+         *         "ebe03b69-c966-42fb-ae3f-4a8c9e5b909e"
+         *       ]
+         *     }
+         */
+        AllowedFunctionsResponse: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            /**
+             * Restricted
+             * @description False if the endpoint allows execution of any function. True if the endpoint will only execute functions from it's allowed list; see the functions field.
+             */
+            restricted: boolean;
+            /**
+             * Functions
+             * @description The functions this endpoint is allowed to execute
+             */
+            functions?: string[];
+        };
+        /**
+         * BatchStatusRequest
+         * @example {
+         *       "task_ids": [
+         *         "7dac44aa-c480-4460-b453-a47b03b031f4",
+         *         "4b35645f-0c5b-465d-aaec-fee87f74ff5b"
+         *       ]
+         *     }
+         */
+        BatchStatusRequest: {
+            /**
+             * Task Ids
+             * @description Task UUIDs
+             */
+            task_ids: string[];
+        };
+        /**
+         * BatchStatusResponse
+         * @example {
+         *       "response": "batch",
+         *       "results": {
+         *         "7dac44aa-c480-4460-b453-a47b03b031f4": {
+         *           "task_id": "7dac44aa-c480-4460-b453-a47b03b031f4",
+         *           "status": "success",
+         *           "result": "10000",
+         *           "completion_t": "1677183605.212898"
+         *         },
+         *         "4b35645f-0c5b-465d-aaec-fee87f74ff5b": {
+         *           "task_id": "4b35645f-0c5b-465d-aaec-fee87f74ff5b",
+         *           "status": "failed",
+         *           "reason": "Task failed"
+         *         }
+         *       }
+         *     }
+         */
+        BatchStatusResponse: {
+            /**
+             * Response
+             * @description Response
+             */
+            response: string;
+            /**
+             * Results
+             * @description Task results
+             */
+            results: {
+                [key: string]: components["schemas"]["BatchStatusResponseResults"];
+            };
+        };
+        /** BatchStatusResponseResults */
+        BatchStatusResponseResults: {
+            /**
+             * Task Id
+             * Format: uuid
+             * @description Task UUID
+             */
+            task_id: string;
+            /**
+             * Status
+             * @description Task status
+             */
+            status?: unknown;
+            /**
+             * Result
+             * @description Task result
+             */
+            result?: string;
+            /**
+             * Completion T
+             * @description Task completion Unix time
+             */
+            completion_t?: string;
+            /**
+             * Exception
+             * @description Exception
+             */
+            exception?: string;
+            /**
+             * Reason
+             * @description Reason for exception
+             */
+            reason?: string;
+        };
+        /** BatchSubmitResponseTask */
+        BatchSubmitResponseTask: {
+            /**
+             * Status
+             * @description Task status
+             */
+            status: string;
+            /**
+             * Task Uuid
+             * Format: uuid
+             * @description Task UUID
+             */
+            task_uuid: string;
+            /**
+             * Http Status Code
+             * @description HTTP status code
+             */
+            http_status_code: number;
+            /**
+             * Reason
+             * @description Reason for exception
+             */
+            reason?: string;
+        };
+        /**
+         * BuildStatus
+         * @description An enumeration.
+         * @enum {string}
+         */
+        BuildStatus: "provided" | "submitted" | "initialized" | "queued" | "building" | "ready" | "failed";
+        /** ConsoleNodeInfo */
+        ConsoleNodeInfo: {
+            /**
+             * Total Worker Count
+             * @description Total number of provisioned workers on the node
+             */
+            total_worker_count?: number;
+            /**
+             * Idle Duration Seconds
+             * @description Idle duration in seconds
+             */
+            idle_duration_seconds?: number;
+            /**
+             * Python Version
+             * @description Node Python version
+             */
+            python_version?: string;
+            /**
+             * Endpoint Version
+             * @description Version of `globus-compute-endpoint` running on the node
+             */
+            endpoint_version?: string;
+            /**
+             * Sdk Version
+             * @description Version of `globus-compute-sdk` running on the node
+             */
+            sdk_version?: string;
+        };
+        /**
+         * ConsoleResponse
+         * @example {
+         *       "user_endpoints": [
+         *         {
+         *           "user_endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *           "active": true,
+         *           "python_version": "3.12.7",
+         *           "endpoint_version": "3.1.1",
+         *           "posix_pid": 12345,
+         *           "posix_username": "test_user",
+         *           "start_time_iso": "2025-01-02T21:20:19.123456-05:00",
+         *           "start_time_unix": 1735870819.123456,
+         *           "last_heartbeat_unix": 1735884207.498273,
+         *           "running_task_count": 3,
+         *           "queued_task_count": 0,
+         *           "executed_task_count": 15,
+         *           "total_worker_count": 2,
+         *           "idle_worker_count": 0,
+         *           "total_node_count": 1,
+         *           "node_info": {
+         *             "some_job_id": [
+         *               {
+         *                 "total_worker_count": 2,
+         *                 "idle_duration_seconds": 0,
+         *                 "python_version": "3.12.7",
+         *                 "endpoint_version": "3.1.1",
+         *                 "sdk_version": "3.1.1"
+         *               }
+         *             ]
+         *           },
+         *           "engine_type": "GlobusComputeEngine",
+         *           "provider_type": "SlurmProvider",
+         *           "account": "my-slurm-account",
+         *           "queue": "caslake",
+         *           "config": "engine:\n  type: GlobusComputeEngine\n  max_workers_per_node: 2\n  provider:\n    type: SlurmProvider\n    account: my-slurm-account\n    partition: caslake\n    worker_init: 'module load Anaconda; source activate compute-env'\n    nodes_per_block: 1\n    max_blocks: 1\n  address:\n    type: address_by_interface\n    ifname: bond0\n"
+         *         }
+         *       ]
+         *     }
+         */
+        ConsoleResponse: {
+            /**
+             * User Endpoints
+             * @description List of information about each running user endpoint process
+             */
+            user_endpoints: components["schemas"]["ConsoleUserEndpointInfo"][];
+        };
+        /** ConsoleUserEndpointInfo */
+        ConsoleUserEndpointInfo: {
+            /**
+             * User Endpoint Id
+             * Format: uuid
+             * @description User endpoint UUID (key identifier)
+             */
+            user_endpoint_id: string;
+            /**
+             * Active
+             * @description Whether the user endpoint is active
+             * @default true
+             */
+            active: boolean;
+            /**
+             * Python Version
+             * @description User endpoint Python version
+             */
+            python_version?: string;
+            /**
+             * Endpoint Version
+             * @description User endpoint version
+             */
+            endpoint_version?: string;
+            /**
+             * Posix Pid
+             * @description User endpoint process ID
+             */
+            posix_pid?: number;
+            /**
+             * Posix Username
+             * @description Local POSIX user running the user endpoint
+             */
+            posix_username?: string;
+            /**
+             * Start Time Iso
+             * Format: date-time
+             * @description User endpoint start time in ISO format including timezone offset
+             */
+            start_time_iso?: string;
+            /**
+             * Start Time Unix
+             * @description UNIX timestamp indicating when the user endpoint was started
+             */
+            start_time_unix?: number;
+            /**
+             * Last Heartbeat Unix
+             * @description UNIX timestamp indicating when the services last processed a heartbeat for the user endpoint
+             */
+            last_heartbeat_unix?: number;
+            /**
+             * Total Worker Count
+             * @description Total number of provisioned workers
+             */
+            total_worker_count?: number;
+            /**
+             * Idle Worker Count
+             * @description Number of idle workers
+             */
+            idle_worker_count?: number;
+            /**
+             * Total Node Count
+             * @description Total number of provisioned nodes
+             */
+            total_node_count?: number;
+            /**
+             * Node Info
+             * @description Details for each provisioned node, indexed by job ID
+             */
+            node_info?: {
+                [key: string]: components["schemas"]["ConsoleNodeInfo"][];
+            };
+            /**
+             * Running Task Count
+             * @description Number of running tasks
+             */
+            running_task_count?: number;
+            /**
+             * Queued Task Count
+             * @description Number of queued tasks
+             */
+            queued_task_count?: number;
+            /**
+             * Executed Task Count
+             * @description Number of executed tasks
+             */
+            executed_task_count?: number;
+            /**
+             * Engine Type
+             * @description User endpoint engine type. See our documentation for more information: https://globus-compute.readthedocs.io/en/latest/endpoints/config_reference.html#user-endpoint-configuration
+             */
+            engine_type?: string;
+            /**
+             * Provider Type
+             * @description User endpoint provider type. See our documentation for more information: https://globus-compute.readthedocs.io/en/latest/endpoints/config_reference.html#user-endpoint-configuration
+             */
+            provider_type?: string;
+            /**
+             * Account
+             * @description The account against which the scheduler charges resources that are consumed by the user endpoint
+             */
+            account?: string;
+            /**
+             * Queue
+             * @description The scheduler queue to which the user endpoint will submit jobs
+             */
+            queue?: string;
+            /**
+             * Config
+             * @description User endpoint configuration YAML content. We do not include this field by default because it may be quite large. Users must explicitly request it using the `include_fields` query parameter.
+             */
+            config?: string;
+        };
+        /**
+         * ContainerBuildRequest
+         * @example {
+         *       "name": "My Container",
+         *       "description": "Container with vim and git installed using apt and numpy and pandas installed using pip.",
+         *       "apt": [
+         *         "vim",
+         *         "git"
+         *       ],
+         *       "pip": [
+         *         "numpy",
+         *         "pandas"
+         *       ],
+         *       "conda": [],
+         *       "payload_url": "https://github.com/my-container"
+         *     }
+         */
+        ContainerBuildRequest: {
+            /**
+             * Name
+             * @description Container name
+             */
+            name: string;
+            /**
+             * Description
+             * @description Long container description
+             */
+            description?: string;
+            /**
+             * Apt
+             * @description Optional list of package names to be installed via apt-get
+             */
+            apt: string[];
+            /**
+             * Pip
+             * @description Optional list of pip requirements (name and optional version specifier)
+             */
+            pip: string[];
+            /**
+             * Conda
+             * @description Optional list of conda requirements (name and optional version specifier)
+             */
+            conda: string[];
+            /**
+             * Payload Url
+             * Format: uri
+             * @description URL to GitHub repo or publicly readable zip file
+             */
+            payload_url?: string;
+        };
+        /**
+         * ContainerBuildResponse
+         * @example {
+         *       "container_id": "b7a42fa2-e97f-4061-9e64-2ede22ae7f5e"
+         *     }
+         */
+        ContainerBuildResponse: {
+            /**
+             * Container Id
+             * Format: uuid
+             * @description Container UUID
+             */
+            container_id: string;
+        };
+        /**
+         * ContainerBuildStatusResponse
+         * @example {
+         *       "status": "ready"
+         *     }
+         */
+        ContainerBuildStatusResponse: {
+            /** @description Container build status */
+            status: components["schemas"]["BuildStatus"];
+        };
+        /**
+         * ContainerRegisterRequest
+         * @example {
+         *       "name": "My Container",
+         *       "description": "My container description",
+         *       "type": "docker",
+         *       "location": "docker://my-container:latest"
+         *     }
+         */
+        ContainerRegisterRequest: {
+            /**
+             * Name
+             * @description Container name
+             */
+            name: string;
+            /**
+             * Description
+             * @description Long container description
+             */
+            description?: string;
+            type: components["schemas"]["ContainerRuntime"];
+            /**
+             * Location
+             * @description The location of the container (e.g., its docker url)
+             */
+            location: string;
+        };
+        /**
+         * ContainerRegisterResponse
+         * @example {
+         *       "container_id": "b7a42fa2-e97f-4061-9e64-2ede22ae7f5e"
+         *     }
+         */
+        ContainerRegisterResponse: {
+            /**
+             * Container Id
+             * Format: uuid
+             * @description Container UUID
+             */
+            container_id: string;
+        };
+        /**
+         * ContainerRuntime
+         * @description Runtime to be used to execute the container.
+         * @enum {string}
+         */
+        ContainerRuntime: "docker" | "singularity";
+        /** ContainerStatus */
+        ContainerStatus: {
+            /**
+             * Container Uuid
+             * Format: uuid
+             * @description Container UUID
+             */
+            container_uuid: string;
+            /**
+             * Name
+             * @description Container name
+             */
+            name: string;
+            /** @description Container build status */
+            build_status: components["schemas"]["BuildStatus"];
+            type?: components["schemas"]["ContainerRuntime"];
+            /**
+             * Location
+             * @description Container location
+             */
+            location?: string;
+            /**
+             * Build Stderr
+             * @description Container build stderr
+             */
+            build_stderr?: string;
+            /**
+             * Err Message
+             * @description Container error message
+             */
+            err_message?: string;
+        };
+        /**
+         * ContainerStatusResponse
+         * @example {
+         *       "container": {
+         *         "container_uuid": "b7a42fa2-e97f-4061-9e64-2ede22ae7f5e",
+         *         "name": "My Container",
+         *         "build_status": "ready",
+         *         "type": "docker",
+         *         "location": "docker://my-container:latest"
+         *       }
+         *     }
+         */
+        ContainerStatusResponse: {
+            container: components["schemas"]["ContainerStatus"];
+        };
+        /**
+         * DeleteFunctionResponse
+         * @example {
+         *       "result": 302
+         *     }
+         */
+        DeleteFunctionResponse: {
+            /**
+             * Result
+             * @description The result as a status code integer
+             */
+            result: number;
+        };
+        /**
+         * Endpoint
+         * @example {
+         *       "uuid": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "name": "My Endpoint",
+         *       "display_name": "My Endpoint's display name",
+         *       "multi_user": false,
+         *       "high_assurance": false,
+         *       "public": false,
+         *       "endpoint_config": "",
+         *       "user_config_template": {},
+         *       "user_config_schema": {},
+         *       "description": "My endpoint description",
+         *       "hostname": "my-endpoint",
+         *       "local_user": "user",
+         *       "ip_address": "140.221.112.13",
+         *       "endpoint_version": "1.0.10",
+         *       "sdk_version": "1.0.10",
+         *       "python_version": "3.12.7",
+         *       "subscription_uuid": "b0b7b089-707a-4d90-a036-05b7964d6b60"
+         *     }
+         */
+        Endpoint: {
+            /**
+             * Uuid
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            uuid: string;
+            /**
+             * Name
+             * @description Endpoint name
+             */
+            name: string;
+            /**
+             * Display Name
+             * @description Display name
+             */
+            display_name: string;
+            /**
+             * Multi User
+             * @description Endpoint multi-user mode
+             */
+            multi_user: boolean;
+            /**
+             * High Assurance
+             * @description Endpoint supports high-assurance protocols
+             */
+            high_assurance: boolean;
+            /**
+             * Public
+             * @description Indicates if all users can discover the multi-user endpoint.
+             */
+            public: boolean;
+            /**
+             * Config
+             * @deprecated
+             * @description This field is deprecated. Please use endpoint_config instead.
+             */
+            config?: Record<string, unknown>;
+            /**
+             * Endpoint Config
+             * @description The contents of the endpoint's configuration file (config.yaml).
+             */
+            endpoint_config?: string;
+            /**
+             * User Config Template
+             * @description Multi-user endpoints will render this Jinja template with user-provided variables to generate a user-specific endpoint configuration.
+             */
+            user_config_template?: string;
+            /**
+             * User Config Schema
+             * @description User endpoint configuration schema
+             */
+            user_config_schema?: Record<string, unknown>;
+            /**
+             * Description
+             * @description Endpoint description
+             */
+            description?: string;
+            /**
+             * Hostname
+             * @description Endpoint hostname
+             */
+            hostname?: string;
+            /**
+             * Local User
+             * @description Endpoint local user
+             */
+            local_user?: string;
+            /**
+             * Ip Address
+             * Format: ipvanyaddress
+             * @description Endpoint IP address
+             */
+            ip_address?: string;
+            /**
+             * Endpoint Version
+             * @description Endpoint version
+             */
+            endpoint_version?: string;
+            /**
+             * Sdk Version
+             * @description Endpoint SDK version
+             */
+            sdk_version?: string;
+            /**
+             * Python Version
+             * @description Endpoint Python version
+             */
+            python_version?: string;
+            /**
+             * Subscription Uuid
+             * Format: uuid
+             * @description Globus subscription UUID
+             */
+            subscription_uuid?: string;
+        };
+        /**
+         * EndpointConfig
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "task_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue"
+         *       },
+         *       "result_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue",
+         *         "queue_publish_kwargs": {
+         *           "exchange": "some_exchange",
+         *           "routing_key": "some_key",
+         *           "mandatory": true,
+         *           "properties": {
+         *             "delivery_mode": 2
+         *           }
+         *         }
+         *       },
+         *       "warnings": []
+         *     }
+         */
+        EndpointConfig: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            task_queue_info: components["schemas"]["EndpointConfigQueueInfo"];
+            result_queue_info: components["schemas"]["EndpointConfigResultQueue"];
+            /**
+             * Warnings
+             * @description Warnings
+             */
+            warnings?: string[];
+        };
+        /** EndpointConfigQueueInfo */
+        EndpointConfigQueueInfo: {
+            /**
+             * Connection Url
+             * @description Connection URL
+             */
+            connection_url: string;
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Queue
+             * @description Queue
+             */
+            queue: string;
+        };
+        /** EndpointConfigResultQueue */
+        EndpointConfigResultQueue: {
+            /**
+             * Connection Url
+             * @description Connection URL
+             */
+            connection_url: string;
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Queue
+             * @description Queue
+             */
+            queue: string;
+            queue_publish_kwargs: components["schemas"]["EndpointConfigResultQueuePublish"];
+        };
+        /** EndpointConfigResultQueuePublish */
+        EndpointConfigResultQueuePublish: {
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Routing Key
+             * @description Routing key
+             */
+            routing_key: string;
+            /**
+             * Mandatory
+             * @description Mandatory
+             */
+            mandatory: boolean;
+            properties: components["schemas"]["EndpointConfigResultQueuePublishProperties"];
+        };
+        /** EndpointConfigResultQueuePublishProperties */
+        EndpointConfigResultQueuePublishProperties: {
+            /**
+             * Delivery Mode
+             * @description Delivery mode
+             */
+            delivery_mode: number;
+        };
+        /**
+         * EndpointDeleteResponse
+         * @example {
+         *       "result": 302
+         *     }
+         */
+        EndpointDeleteResponse: {
+            /**
+             * Result
+             * @description The result as a status code integer
+             */
+            result: number;
+        };
+        /**
+         * EndpointListResponseEntry
+         * @example {
+         *       "uuid": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "name": "My Endpoint",
+         *       "display_name": "My Endpoint's display name",
+         *       "owner": "0b3390f4-ca5f-496d-a7b9-9e4faed46bff"
+         *     }
+         */
+        EndpointListResponseEntry: {
+            /**
+             * Uuid
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            uuid: string;
+            /**
+             * Name
+             * @description Endpoint name
+             */
+            name: string;
+            /**
+             * Display Name
+             * @description Display name
+             */
+            display_name: string;
+            /**
+             * Owner
+             * Format: uuid
+             * @description Endpoint owner's identity ID
+             */
+            owner: string;
+        };
+        /** EndpointMetadata */
+        EndpointMetadata: {
+            /**
+             * Config
+             * @deprecated
+             * @description This field is deprecated. Please use endpoint_config instead.
+             */
+            config?: Record<string, unknown>;
+            /**
+             * Endpoint Config
+             * @description The contents of the endpoint's configuration file (config.yaml).
+             */
+            endpoint_config?: string;
+            /**
+             * User Config Template
+             * @description Multi-user endpoints will render this Jinja template with user-provided variables to generate a user-specific endpoint configuration.
+             */
+            user_config_template?: string;
+            /**
+             * User Config Schema
+             * @description User endpoint configuration schema
+             */
+            user_config_schema?: Record<string, unknown>;
+            /**
+             * Description
+             * @description Endpoint description
+             */
+            description?: string;
+            /**
+             * Ip Address
+             * Format: ipvanyaddress
+             * @description Endpoint IP address
+             */
+            ip_address?: string;
+            /**
+             * Hostname
+             * @description Endpoint hostname
+             */
+            hostname?: string;
+            /**
+             * Local User
+             * @description Endpoint local user
+             */
+            local_user?: string;
+            /**
+             * Sdk Version
+             * @description Endpoint SDK version
+             */
+            sdk_version?: string;
+            /**
+             * Endpoint Version
+             * @description Endpoint version
+             */
+            endpoint_version?: string;
+            /**
+             * Python Version
+             * @description Endpoint Python version
+             */
+            python_version?: string;
+        };
+        /** EndpointRegisterMetadata */
+        EndpointRegisterMetadata: {
+            /**
+             * Config
+             * @deprecated
+             * @description This field is deprecated. Please use endpoint_config instead.
+             */
+            config?: Record<string, unknown>;
+            /**
+             * Endpoint Config
+             * @description The contents of the endpoint's configuration file (config.yaml).
+             */
+            endpoint_config?: string;
+            /**
+             * User Config Template
+             * @description Multi-user endpoints will render this Jinja template with user-provided variables to generate a user-specific endpoint configuration.
+             */
+            user_config_template?: string;
+            /**
+             * User Config Schema
+             * @description User endpoint configuration schema
+             */
+            user_config_schema?: Record<string, unknown>;
+            /**
+             * Description
+             * @description Endpoint description
+             */
+            description?: string;
+            /**
+             * Ip Address
+             * @description Endpoint IP address
+             */
+            ip_address?: string;
+            /**
+             * Hostname
+             * @description Endpoint hostname
+             */
+            hostname?: string;
+            /**
+             * Local User
+             * @description Endpoint local user
+             */
+            local_user?: string;
+            /**
+             * Sdk Version
+             * @description Endpoint SDK version
+             */
+            sdk_version?: string;
+            /**
+             * Endpoint Version
+             * @description Endpoint version
+             */
+            endpoint_version?: string;
+            /**
+             * Python Version
+             * @description Endpoint Python version
+             */
+            python_version?: string;
+        };
+        /**
+         * EndpointRegisterResponse
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "task_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue"
+         *       },
+         *       "result_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue",
+         *         "queue_publish_kwargs": {
+         *           "exchange": "some_exchange",
+         *           "routing_key": "some_key",
+         *           "mandatory": true,
+         *           "properties": {
+         *             "delivery_mode": 2
+         *           }
+         *         }
+         *       },
+         *       "heartbeat_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue",
+         *         "queue_publish_kwargs": {
+         *           "exchange": "some_exchange",
+         *           "routing_key": "some_key",
+         *           "mandatory": true,
+         *           "properties": {
+         *             "delivery_mode": 2
+         *           }
+         *         }
+         *       }
+         *     }
+         */
+        EndpointRegisterResponse: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            task_queue_info: components["schemas"]["ReadQueueInfo"];
+            result_queue_info: components["schemas"]["WriteQueueInfo"];
+            heartbeat_queue_info: components["schemas"]["WriteQueueInfo"];
+            /**
+             * Warnings
+             * @description Warnings
+             */
+            warnings?: string[];
+        };
+        /** EndpointStatusDetails */
+        EndpointStatusDetails: {
+            /**
+             * Total Workers
+             * @description Total number of workers
+             */
+            total_workers: number;
+            /**
+             * Idle Workers
+             * @description Number of idle workers
+             */
+            idle_workers: number;
+            /**
+             * Pending Tasks
+             * @description Number of pending tasks
+             */
+            pending_tasks: number;
+            /**
+             * Outstanding Tasks
+             * @description Number of outstanding tasks
+             */
+            outstanding_tasks: number;
+            /**
+             * Managers
+             * @description Number of managers
+             */
+            managers?: number;
+        };
+        /**
+         * EndpointStatusResponse
+         * @example {
+         *       "details": {
+         *         "total_workers": 1,
+         *         "idle_workers": 0,
+         *         "pending_tasks": 0,
+         *         "outstanding_tasks": 0,
+         *         "managers": 1
+         *       },
+         *       "status": "online"
+         *     }
+         */
+        EndpointStatusResponse: {
+            details?: components["schemas"]["EndpointStatusDetails"];
+            /**
+             * Status
+             * @description Endpoint status
+             */
+            status: string;
+        };
+        /** ErrorResponse */
+        ErrorResponse: {
+            /** Status */
+            status: string;
+            /** Code */
+            code: string;
+            /** Error Args */
+            error_args: unknown[];
+            /** Http Status Code */
+            http_status_code: number;
+            /** Reason */
+            reason: string;
+        };
+        /**
+         * Function
+         * @example {
+         *       "function_uuid": "11291b86-4f9c-47cb-848e-d3c06285951c",
+         *       "function_name": "My Function",
+         *       "function_code": "wuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0 ...",
+         *       "description": "My first function",
+         *       "metadata": {
+         *         "python_version": "3.11.3",
+         *         "sdk_version": "2.3.3"
+         *       }
+         *     }
+         */
+        Function: {
+            /**
+             * Function Uuid
+             * Format: uuid
+             * @description Function UUID
+             */
+            function_uuid: string;
+            /**
+             * Function Name
+             * @description Function name
+             */
+            function_name?: string;
+            /**
+             * Description
+             * @description Function description
+             */
+            description?: string;
+            /**
+             * Function Code
+             * @description Serialized function source code
+             */
+            function_code: string;
+            /**
+             * Metadata
+             * @description Function metadata
+             */
+            metadata: components["schemas"]["FunctionMetadata"];
+        };
+        /** FunctionMetadata */
+        FunctionMetadata: {
+            /**
+             * Python Version
+             * @description Python version used to serialize function.
+             */
+            python_version?: string;
+            /**
+             * Sdk Version
+             * @description SDK version used to serialize function.
+             */
+            sdk_version?: string;
+        };
+        /**
+         * FuncxStatsResponse
+         * @example {
+         *       "total_function_invocations": 100
+         *     }
+         */
+        FuncxStatsResponse: {
+            /**
+             * Total Function Invocations
+             * @description Total function invocations
+             */
+            total_function_invocations: number;
+        };
+        /**
+         * FuncxVersionResponse
+         * @example {
+         *       "api": "1.0.9",
+         *       "min_sdk_version": "1.0.10",
+         *       "min_ep_version": "1.0.10",
+         *       "git_sha": "3ae0ff6bc42b6d5f9d92f3c426fe9e535a841hb6",
+         *       "container_service": "0.0.1"
+         *     }
+         */
+        FuncxVersionResponse: {
+            /**
+             * Api
+             * @description API version
+             */
+            api: string;
+            /**
+             * Min Sdk Version
+             * @description Minimum SDK version
+             */
+            min_sdk_version?: string;
+            /**
+             * Min Ep Version
+             * @description Minimum endpoint version
+             */
+            min_ep_version?: string;
+            /**
+             * Git Sha
+             * @description Git SHA of the latest commit
+             */
+            git_sha?: string;
+            /**
+             * Container Service
+             * @description Container service version
+             */
+            container_service?: string;
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /** MultiUserEndpointConfig */
+        MultiUserEndpointConfig: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            command_queue_info: components["schemas"]["EndpointConfigQueueInfo"];
+            /**
+             * Warnings
+             * @description Warnings
+             */
+            warnings?: string[];
+        };
+        /**
+         * MultiUserEndpointRegisterResponse
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "command_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue"
+         *       },
+         *       "result_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue",
+         *         "queue_publish_kwargs": {
+         *           "exchange": "some_exchange",
+         *           "routing_key": "some_key",
+         *           "mandatory": true,
+         *           "properties": {
+         *             "delivery_mode": 2
+         *           }
+         *         }
+         *       },
+         *       "heartbeat_queue_info": {
+         *         "connection_url": "amqps://user:password@mq.fqdn",
+         *         "exchange": "some_exchange",
+         *         "queue": "some_queue",
+         *         "queue_publish_kwargs": {
+         *           "exchange": "some_exchange",
+         *           "routing_key": "some_key",
+         *           "mandatory": true,
+         *           "properties": {
+         *             "delivery_mode": 2
+         *           }
+         *         }
+         *       }
+         *     }
+         */
+        MultiUserEndpointRegisterResponse: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            command_queue_info: components["schemas"]["ReadQueueInfo"];
+            result_queue_info: components["schemas"]["WriteQueueInfo"];
+            heartbeat_queue_info: components["schemas"]["WriteQueueInfo"];
+            /**
+             * Warnings
+             * @description Warnings
+             */
+            warnings?: string[];
+        };
+        /** ReadQueueInfo */
+        ReadQueueInfo: {
+            /**
+             * Connection Url
+             * @description Connection URL
+             */
+            connection_url: string;
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Queue
+             * @description Queue
+             */
+            queue: string;
+        };
+        /** RegisterFunctionMetadata */
+        RegisterFunctionMetadata: {
+            /**
+             * Python Version
+             * @description Python version used to serialize function.
+             */
+            python_version?: string;
+            /**
+             * Sdk Version
+             * @description SDK version used to serialize function.
+             */
+            sdk_version?: string;
+        };
+        /**
+         * RegisterFunctionRequest
+         * @example {
+         *       "function_name": "My Function",
+         *       "function_code": "wuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0 ...",
+         *       "description": "My first function",
+         *       "metadata": {
+         *         "python_version": "3.11.3",
+         *         "sdk_version": "2.3.3"
+         *       },
+         *       "container_uuid": "b7a42fa2-e97f-4061-9e64-2ede22ae7f5e",
+         *       "group": "a2d6feb6-5386-4a06-8a22-99ea5ad7e651",
+         *       "public": false
+         *     }
+         */
+        RegisterFunctionRequest: {
+            /**
+             * Function Name
+             * @description Function name
+             */
+            function_name: string;
+            /**
+             * Entry Point
+             * @description (DEPRECATED) Entry point
+             */
+            entry_point?: string;
+            /**
+             * Function Code
+             * @description Serialized function source code
+             */
+            function_code: string;
+            /**
+             * Description
+             * @description Function description
+             */
+            description?: string;
+            metadata?: components["schemas"]["RegisterFunctionMetadata"];
+            /**
+             * Container Uuid
+             * Format: uuid
+             * @description Container UUID
+             */
+            container_uuid?: string;
+            /**
+             * Group
+             * Format: uuid
+             * @description Globus group UUID
+             */
+            group?: string;
+            /**
+             * Public
+             * @description Public function
+             * @default false
+             */
+            public: boolean;
+        };
+        /**
+         * RegisterFunctionResponse
+         * @example {
+         *       "function_uuid": "11291b86-4f9c-47cb-848e-d3c06285951c"
+         *     }
+         */
+        RegisterFunctionResponse: {
+            /**
+             * Function Uuid
+             * Format: uuid
+             * @description Function UUID
+             */
+            function_uuid: string;
+        };
+        /** ResourceSpecification */
+        ResourceSpecification: {
+            /**
+             * Num Nodes
+             * @description Number of nodes required for an MPI application
+             */
+            num_nodes: number;
+            /**
+             * Ranks Per Node
+             * @description Number of MPI ranks to launch per node.
+             */
+            ranks_per_node?: number;
+            /**
+             * Num Ranks
+             * @description Total number of MPI ranks to launch across all nodes.
+             */
+            num_ranks?: number;
+            /**
+             * Launcher Options
+             * @description Options passed through to the MPI launcher command line prefix.
+             */
+            launcher_options?: string;
+        };
+        /**
+         * ResultAmqpUrlResponse
+         * @example {
+         *       "queue_prefix": "some_prefix",
+         *       "connection_url": "amqps://user:password@amq.fqdn"
+         *     }
+         */
+        ResultAmqpUrlResponse: {
+            /**
+             * Queue Prefix
+             * @description Queue prefix
+             */
+            queue_prefix: string;
+            /**
+             * Connection Url
+             * Format: uri
+             * @description Connection URL
+             */
+            connection_url: string;
+        };
+        /**
+         * TaskGroupResponse
+         * @example {
+         *       "taskgroup_id": "4defbef8-0a1a-4c7b-9c83-b59174fca395",
+         *       "create_websockets_queue": true,
+         *       "tasks": [
+         *         {
+         *           "id": "9e38ed49-7d05-45c4-9ad0-bfa3bc92d6a1",
+         *           "created_at": "2021-05-05T15:00:00.000000"
+         *         }
+         *       ]
+         *     }
+         */
+        TaskGroupResponse: {
+            /**
+             * Taskgroup Id
+             * Format: uuid
+             * @description Task Group UUID
+             */
+            taskgroup_id: string;
+            /**
+             * Create Websockets Queue
+             * @description Create websockets queue
+             */
+            create_websockets_queue?: boolean;
+            /** Tasks */
+            tasks: components["schemas"]["TaskGroupResponseTask"][];
+        };
+        /** TaskGroupResponseTask */
+        TaskGroupResponseTask: {
+            /**
+             * Id
+             * Format: uuid
+             * @description Task UUID
+             */
+            id: string;
+            /**
+             * Created At
+             * Format: date-time
+             * @description Task creation time
+             */
+            created_at: string;
+        };
+        /**
+         * TaskStatusResponse
+         * @example {
+         *       "task_id": "7dac44aa-c480-4460-b453-a47b03b031f4",
+         *       "status": "success",
+         *       "result": "10000",
+         *       "completion_t": "1677183605.212898",
+         *       "details": {
+         *         "os": "Linux-5.19.0-1025-aws-x86_64-with-glibc2.35",
+         *         "python_version": "3.10.4",
+         *         "dill_version": "0.3.5.1",
+         *         "globus_compute_sdk_version": "2.3.2",
+         *         "task_transitions": {
+         *           "execution-start": 1692742841.843334,
+         *           "execution-end": 1692742846.123456
+         *         }
+         *       }
+         *     }
+         */
+        TaskStatusResponse: {
+            /**
+             * Task Id
+             * Format: uuid
+             * @description Task UUID
+             */
+            task_id: string;
+            /**
+             * Status
+             * @description Task status
+             */
+            status?: unknown;
+            /**
+             * Result
+             * @description Task result
+             */
+            result?: string;
+            /**
+             * Completion T
+             * @description Task completion Unix time
+             */
+            completion_t?: string;
+            /**
+             * Exception
+             * @description Exception
+             */
+            exception?: string;
+            /**
+             * Details
+             * @description Task execution details
+             */
+            details?: Record<string, unknown>;
+        };
+        /** UserRuntime */
+        UserRuntime: {
+            /**
+             * Globus Compute Sdk Version
+             * @description Version of the Globus Compute SDK used to submit this batch.
+             */
+            globus_compute_sdk_version?: string;
+            /**
+             * Globus Sdk Version
+             * @description Version of the Globus SDK used to submit this batch.
+             */
+            globus_sdk_version?: string;
+            /**
+             * Python Version
+             * @description Python version that ran the SDK and submitted this batch.
+             */
+            python_version?: string;
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
+        /** ValidationErrorResponse */
+        ValidationErrorResponse: {
+            /** Status */
+            status: string;
+            /** Code */
+            code: string;
+            /** Error Args */
+            error_args: unknown[];
+            /** Http Status Code */
+            http_status_code: number;
+            /** Reason */
+            reason: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * VersionService
+         * @description An enumeration.
+         * @enum {string}
+         */
+        VersionService: "api" | "all";
+        /** WriteQueueInfo */
+        WriteQueueInfo: {
+            /**
+             * Connection Url
+             * @description Connection URL
+             */
+            connection_url: string;
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Queue
+             * @description Queue
+             */
+            queue: string;
+            queue_publish_kwargs: components["schemas"]["WriteQueuePublishKwargs"];
+        };
+        /** WriteQueuePublishKwargs */
+        WriteQueuePublishKwargs: {
+            /**
+             * Exchange
+             * @description Exchange
+             */
+            exchange: string;
+            /**
+             * Routing Key
+             * @description Routing key
+             */
+            routing_key: string;
+            /**
+             * Mandatory
+             * @description Mandatory
+             */
+            mandatory: boolean;
+            properties: components["schemas"]["WriteQueuePublishProperties"];
+        };
+        /** WriteQueuePublishProperties */
+        WriteQueuePublishProperties: {
+            /**
+             * Delivery Mode
+             * @description Delivery mode
+             */
+            delivery_mode: number;
+        };
+        /**
+         * EndpointLockResponse
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "lock_expiration_timestamp": "2021-07-01T00:00:00.000000"
+         *     }
+         */
+        funcx_web_service__schemas__v2__endpoint__EndpointLockResponse: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            /**
+             * Lock Expiration Timestamp
+             * Format: date-time
+             * @description Lock expiration timestamp
+             */
+            lock_expiration_timestamp: string;
+        };
+        /**
+         * EndpointRegisterRequest
+         * @example {
+         *       "endpoint_name": "My Endpoint",
+         *       "display_name": "My Endpoint's display name",
+         *       "endpoint_uuid": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "version": "1.0.10",
+         *       "multi_user": false,
+         *       "allowed_functions": [
+         *         "11291b86-4f9c-47cb-848e-d3c06285951c"
+         *       ],
+         *       "authentication_policy": "67b4e120-2638-4771-86bb-6ac2a0f69e0b",
+         *       "metadata": {
+         *         "endpoint_config": "",
+         *         "user_config_template": {},
+         *         "user_config_schema": {},
+         *         "description": "My endpoint description",
+         *         "ip_address": "140.221.112.13",
+         *         "hostname": "my-endpoint",
+         *         "local_user": "user",
+         *         "sdk_version": "1.0.10",
+         *         "endpoint_version": "1.0.10",
+         *         "python_version": "3.12.7"
+         *       }
+         *     }
+         */
+        funcx_web_service__schemas__v2__endpoint__EndpointRegisterRequest: {
+            /**
+             * Endpoint Name
+             * @description Endpoint name
+             */
+            endpoint_name: string;
+            /**
+             * Display Name
+             * @description Endpoint display name
+             */
+            display_name?: string;
+            /**
+             * Endpoint Uuid
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_uuid: string;
+            /**
+             * Version
+             * @description Endpoint version
+             */
+            version?: string;
+            /**
+             * Multi User
+             * @description Endpoint multi-user mode
+             * @default false
+             */
+            multi_user: boolean;
+            /**
+             * Allowed Functions
+             * @description Functions that are allowed to be run on the endpoint
+             */
+            allowed_functions?: string[];
+            /**
+             * Authentication Policy
+             * Format: uuid
+             * @description Endpoint users are evaluated against this Globus authentication policy. For more information on Globus authentication policies, visit https://docs.globus.org/api/auth/developer-guide/#authentication-policies.
+             */
+            authentication_policy?: string;
+            metadata?: components["schemas"]["EndpointRegisterMetadata"];
+        };
+        /**
+         * BatchSubmitRequest
+         * @example {
+         *       "task_group_id": "97241626-8ff4-4550-9938-5909bd221869",
+         *       "create_websocket_queue": false,
+         *       "tasks": [
+         *         [
+         *           "116f1b48-0aab-4228-92f0-021c2ab14b5e",
+         *           "ff960aba-fa23-43d5-9cbe-3f4f91a066e1",
+         *           "... <serialized_arguments> ..."
+         *         ],
+         *         [
+         *           "116f1b48-0aab-4228-92f0-021c2ab14b5e",
+         *           "ff960aba-fa23-43d5-9cbe-3f4f91a066e1",
+         *           "... <serialized_arguments> ..."
+         *         ]
+         *       ]
+         *     }
+         */
+        funcx_web_service__schemas__v2__task__BatchSubmitRequest: {
+            /**
+             * Task Group Id
+             * Format: uuid
+             * @description Task group UUID
+             */
+            task_group_id?: string;
+            /**
+             * Create Websocket Queue
+             * @description Create websocket queue
+             * @default true
+             */
+            create_websocket_queue: boolean;
+            /**
+             * Tasks
+             * @description List of tasks to invoke, each referencing function and endpoint UUIDs.
+             */
+            tasks: [
+                string,
+                string,
+                string
+            ][];
+        };
+        /**
+         * BatchSubmitResponse
+         * @example {
+         *       "response": "success",
+         *       "task_group_id": "97241626-8ff4-4550-9938-5909bd221869",
+         *       "results": [
+         *         {
+         *           "status": "success",
+         *           "task_uuid": "7dac44aa-c480-4460-b453-a47b03b031f4",
+         *           "http_status_code": 200
+         *         },
+         *         {
+         *           "status": "success",
+         *           "task_uuid": "4b35645f-0c5b-465d-aaec-fee87f74ff5b",
+         *           "http_status_code": 200
+         *         }
+         *       ]
+         *     }
+         */
+        funcx_web_service__schemas__v2__task__BatchSubmitResponse: {
+            /**
+             * Response
+             * @description Response
+             */
+            response: string;
+            /**
+             * Task Group Id
+             * Format: uuid
+             * @description Task group UUID
+             */
+            task_group_id?: string;
+            /**
+             * Results
+             * @description Task results
+             */
+            results: (components["schemas"]["BatchSubmitResponseTask"] | string)[];
+        };
+        /**
+         * EndpointLockResponse
+         * @example {
+         *       "endpoint_id": "7348422a-1074-427b-a08a-0771068afccc",
+         *       "lock_expiration_timestamp": "1687531403.0434475"
+         *     }
+         */
+        funcx_web_service__schemas__v3__endpoints__EndpointLockResponse: {
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description Endpoint UUID
+             */
+            endpoint_id: string;
+            /**
+             * Lock Expiration Timestamp
+             * @description Lock expiration UNIX timestamp
+             */
+            lock_expiration_timestamp: number;
+        };
+        /**
+         * EndpointRegisterRequest
+         * @example {
+         *       "endpoint_name": "my_endpoint",
+         *       "display_name": "My Endpoint's Display Name",
+         *       "version": "2.2.0",
+         *       "multi_user": false,
+         *       "public": false,
+         *       "high_assurance": false,
+         *       "allowed_functions": [
+         *         "11291b86-4f9c-47cb-848e-d3c06285951c"
+         *       ],
+         *       "authentication_policy": "67b4e120-2638-4771-86bb-6ac2a0f69e0b",
+         *       "subscription_uuid": "59b63c41-a765-4971-ac9a-41742059ade3",
+         *       "metadata": {
+         *         "endpoint_config": "",
+         *         "user_config_template": {},
+         *         "user_config_schema": {},
+         *         "description": "My endpoint description",
+         *         "ip_address": "140.221.112.13",
+         *         "hostname": "my-endpoint",
+         *         "local_user": "user",
+         *         "sdk_version": "2.2.0",
+         *         "endpoint_version": "2.2.0",
+         *         "python_version": "3.12.7"
+         *       }
+         *     }
+         */
+        funcx_web_service__schemas__v3__endpoints__EndpointRegisterRequest: {
+            /**
+             * Endpoint Name
+             * @description Endpoint name
+             */
+            endpoint_name: string;
+            /**
+             * Display Name
+             * @description Endpoint display name
+             */
+            display_name?: string;
+            /**
+             * Version
+             * @description Endpoint version
+             */
+            version?: string;
+            /**
+             * Multi User
+             * @description Endpoint multi-user mode
+             * @default false
+             */
+            multi_user: boolean;
+            /**
+             * High Assurance
+             * @description Endpoint supports high-assurance protocols
+             * @default false
+             */
+            high_assurance: boolean;
+            /**
+             * Allowed Functions
+             * @description Functions that are allowed to be run on the endpoint
+             */
+            allowed_functions?: string[];
+            /**
+             * Authentication Policy
+             * Format: uuid
+             * @description Endpoint users are evaluated against this Globus authentication policy. For more information on Globus authentication policies, visit https://docs.globus.org/api/auth/developer-guide/#authentication-policies.
+             */
+            authentication_policy?: string;
+            /**
+             * Subscription Uuid
+             * Format: uuid
+             * @description Associates an endpoint with a subscription.
+             */
+            subscription_uuid?: string;
+            /**
+             * Public
+             * @description Indicates if all users can discover the multi-user endpoint. Please note that this field does not control access to the endpoint, so it should not be used as a security feature.
+             * @default false
+             */
+            public: boolean;
+            /**
+             * Metadata
+             * @description Endpoint metadata
+             */
+            metadata: components["schemas"]["EndpointMetadata"];
+        };
+        /**
+         * BatchSubmitRequest
+         * @example {
+         *       "task_group_id": "97241626-8ff4-4550-9938-5909bd221869",
+         *       "user_endpoint_config": {
+         *         "min_blocks": 0,
+         *         "max_blocks": 1,
+         *         "scheduler_options": "#SBATCH --constraint=knl,quad,cache"
+         *       },
+         *       "resource_specification": {
+         *         "num_nodes": 2,
+         *         "ranks_per_node": 2,
+         *         "num_ranks": 4,
+         *         "launcher_options": "--cpu-bind quiet --mem 3072"
+         *       },
+         *       "create_queue": true,
+         *       "tasks": {
+         *         "ff960aba-fa23-43d5-9cbe-3f4f91a066e1": [
+         *           "... <serialized_arguments> ...",
+         *           "... <serialized_arguments> ...",
+         *           "..."
+         *         ],
+         *         "0a98fd06-edbd-11ed-abcd-0d705ebb4c49": [
+         *           "... <serialized_arguments> ...",
+         *           "..."
+         *         ]
+         *       }
+         *     }
+         */
+        funcx_web_service__schemas__v3__tasks__BatchSubmitRequest: {
+            /**
+             * Task Group Id
+             * Format: uuid
+             * @description Associate the request tasks with specified Task Group identifier; if not specified or invalid, a new identifier will be generated and returned in the response
+             */
+            task_group_id?: string;
+            /**
+             * User Endpoint Config
+             * @description Specify user endpoint configuration values as described and allowed by endpoint administrators.
+             */
+            user_endpoint_config?: Record<string, unknown>;
+            /**
+             * Resource Specification
+             * @description Specify resource requirements for individual task execution.
+             */
+            resource_specification?: components["schemas"]["ResourceSpecification"];
+            /**
+             * Create Queue
+             * @description If `true`, create a Task Group specific AMQP queue for the results.  In addition to the usual longer-term storage, results will also be copied to this AMQP queue, enabling consumers to get event-driven (instant) results.  (See the [Globus Compute SDK Executor](https://globus-compute.readthedocs.io/en/stable/executor.html) for an implementation that uses this feature.)
+             * @default false
+             */
+            create_queue: boolean;
+            /**
+             * Tasks
+             * @description Lists of serialized task arguments (strings), grouped by function identifiers
+             */
+            tasks: {
+                [key: string]: string[];
+            };
+            /**
+             * User Runtime
+             * @description Information about the runtime that submitted this batch, such as Python and Globus Compute SDK versions.
+             */
+            user_runtime?: components["schemas"]["UserRuntime"];
+        };
+        /**
+         * BatchSubmitResponse
+         * @example {
+         *       "request_id": "5158de19-10b5-4deb-9d87-a86c1dec3460",
+         *       "task_group_id": "97241626-8ff4-4550-9938-5909bd221869",
+         *       "endpoint_id": "116f1b48-0aab-4228-92f0-021c2ab14b5e",
+         *       "tasks": {
+         *         "ff960aba-fa23-43d5-9cbe-3f4f91a066e1": [
+         *           "89bde6c3-85e9-4834-b0e8-5cb51955eaf5",
+         *           "1e900b37-7a80-424b-aeac-56dd2860f59a",
+         *           "9f12a732-3aa6-4878-9d58-b290837ab096"
+         *         ],
+         *         "0a98fd06-edbd-11ed-abcd-0d705ebb4c49": [
+         *           "022151bf-7b2d-4240-b4d0-9ac5b7077314",
+         *           "1f6f5f1e-15b0-4916-85ff-471511bd35d6"
+         *         ]
+         *       }
+         *     }
+         */
+        funcx_web_service__schemas__v3__tasks__BatchSubmitResponse: {
+            /**
+             * Request Id
+             * @description A unique string to identify the request; currently this is mainly to aid debugging efforts&nbsp;&mdash;&nbsp;such as if a user needs to verify an interaction with Globus Support&nbsp;&mdash;&nbsp;and has no automated API hookup or use elsewhere in the Compute ecosystem
+             */
+            request_id: string;
+            /**
+             * Task Group Id
+             * Format: uuid
+             * @description The Task Group identifier to which the submitted tasks were associated
+             */
+            task_group_id: string;
+            /**
+             * Endpoint Id
+             * Format: uuid
+             * @description The endpoint to which the request's tasks were sent for invocation
+             */
+            endpoint_id: string;
+            /**
+             * Tasks
+             * @description The task identifiers, grouped by the identifier of the function IDs that will execute them.  Note that the order of the identifiers within each list exactly matches the order of serialized arguments in the request.
+             */
+            tasks: {
+                [key: string]: string[];
+            };
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    get_version_v2_version_get: {
+        parameters: {
+            query?: {
+                /** @description Service to get version for */
+                service?: components["schemas"]["VersionService"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string | components["schemas"]["FuncxVersionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_version_v2_version_head: {
+        parameters: {
+            query?: {
+                /** @description Service to get version for */
+                service?: components["schemas"]["VersionService"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_authentication_v2_authenticate_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    get_funcx_stats_v2_stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FuncxStatsResponse"];
+                };
+            };
+        };
+    };
+    get_user_specific_result_amqp_url_v2_get_amqp_result_connection_url_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResultAmqpUrlResponse"];
+                };
+            };
+        };
+    };
+    get_batch_status_v2_batch_status_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_batch_v2_submit_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "content-length": number;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["funcx_web_service__schemas__v2__task__BatchSubmitRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["funcx_web_service__schemas__v2__task__BatchSubmitResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_container_v2_containers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContainerRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerRegisterResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    build_container_v2_containers_build_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContainerBuildRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerBuildResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_container_build_status_v2_containers_build__container_uuid__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                container_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerBuildStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_container_status_v2_containers__container_uuid___container_type__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                container_uuid: string;
+                /** @description Type of containers to return (Docker, Singularity) */
+                container_type: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_endpoints_v2_endpoints_get: {
+        parameters: {
+            query?: {
+                /** @description Role of user in relation to desired endpoints */
+                role?: "owner" | "any";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointListResponseEntry"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_endpoint_v2_endpoints_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "user-agent": string;
+                "x-forwarded-for"?: string;
+                "remote-addr"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["funcx_web_service__schemas__v2__endpoint__EndpointRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointConfig"] | components["schemas"]["MultiUserEndpointConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_endpoint_v2_endpoints__endpoint_uuid__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Endpoint"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_endpoint_v2_endpoints__endpoint_uuid__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_endpoint_status_v2_endpoints__endpoint_uuid__status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    lock_endpoint_v2_endpoints__endpoint_uuid__lock_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["funcx_web_service__schemas__v2__endpoint__EndpointLockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_function_v2_functions__function_uuid__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Function UUID */
+                function_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Function"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_function_v2_functions__function_uuid__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Function UUID */
+                function_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteFunctionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_function_v2_functions_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "user-agent": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterFunctionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegisterFunctionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_task_status_and_result_v2_tasks__task_uuid__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task UUID */
+                task_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_task_group_tasks_v2_taskgroup__task_group_uuid__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task Group UUID */
+                task_group_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskGroupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_endpoint_v3_endpoints_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "user-agent": string;
+                "x-forwarded-for"?: string;
+                "remote-addr"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["funcx_web_service__schemas__v3__endpoints__EndpointRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointRegisterResponse"] | components["schemas"]["MultiUserEndpointRegisterResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Locked */
+            423: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    update_endpoint_v3_endpoints__endpoint_uuid__put: {
+        parameters: {
+            query?: never;
+            header: {
+                "user-agent": string;
+                "x-forwarded-for"?: string;
+                "remote-addr"?: string;
+            };
+            path: {
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["funcx_web_service__schemas__v3__endpoints__EndpointRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EndpointRegisterResponse"] | components["schemas"]["MultiUserEndpointRegisterResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Locked */
+            423: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    lock_endpoint_v3_endpoints__endpoint_uuid__lock_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["funcx_web_service__schemas__v3__endpoints__EndpointLockResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    submit_batch_v3_endpoints__endpoint_uuid__submit_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "content-length": number;
+            };
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["funcx_web_service__schemas__v3__tasks__BatchSubmitRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["funcx_web_service__schemas__v3__tasks__BatchSubmitResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request Entity Too Large */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_endpoint_allowlist_v3_endpoints__endpoint_uuid__allowed_functions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AllowedFunctionsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_endpoint_console_info_v3_endpoints__endpoint_uuid__console_get: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Provide the UUID of a specific user endpoint to return.
+                 * @example 99418dfd-2bcd-473c-a0b5-3aaedd855d82
+                 */
+                user_endpoint_id?: string;
+                /**
+                 * @description Comma separated list of user endpoint fields to include in the response. If left blank, all fields except 'config' are included. Invalid field names will result in a 400 error.
+                 * @example user_endpoint_id,node_info,config
+                 */
+                include_fields?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Multi-user endpoint UUID */
+                endpoint_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsoleResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+}

--- a/src/open-api/types/gcs/v5.4.d.ts
+++ b/src/open-api/types/gcs/v5.4.d.ts
@@ -1,0 +1,11266 @@
+export interface paths {
+    "/api/collections/batch_delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Delete multiple guest collections
+         * @description Initiate the deletion of multiple guest collections. The input document
+         *     contains a list of the IDs of collections to delete.
+         *
+         *     If any of the collections have collection_type of "mapped", then this
+         *     operation returns an error indicating which ones were not valid or this
+         *     operation.
+         *
+         *     If any of the collections do not exist or are already deleted, then they
+         *     are silently ignored.
+         *
+         *     Deletion does not happen immediately; it is handled in the background by
+         *     the GCS Manager Assistant process.
+         *
+         *     On success, this operation returns a message body containing the list of
+         *     collections from the input that this GCS manager node will delete.
+         *
+         */
+        post: operations["postCollectionsBatchDelete"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check the collections on this endpoint */
+        get: operations["checkCollections"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the collections on this endpoint
+         * @description This operation requires either the endpoint to have the `public` property
+         *     set to true or the caller to have a role that allows viewing this
+         *     Collection.
+         *
+         *     The result of this can be limited by using the `filter` query parameter to
+         *     choose which of the visible collections to return.  This is a
+         *     comma-separated list of filters to apply to the result set:
+         *
+         *     <dl>
+         *     <dt>mapped_collections</dt>
+         *         <dd>Only collections with collection_type equal to <em>mapped</em>.</dd>
+         *     <dt>guest_collections</dt>
+         *         <dd>Only collections with collection_type equal to <em>guest</em>.</dd>
+         *     <dt>managed_by_me</dt>
+         *         <dd>Only collections where one of caller's identities (either directly or
+         *         via a group role assignment) is granted a role on the collection.</dd>
+         *     <dt>created_by_me</dt>
+         *         <dd>Only collections where one of the caller's identities matches the
+         *         `identity_id` property of the collection.</dd>
+         *     <dt>last_access < YYYY-MM-DD</dt>
+         *     <dt>last_access <= YYYY-MM-DD</dt>
+         *     <dt>last_access <= YYYY-MM-DD</dt>
+         *     <dt>last_access = YYYY-MM-DD</dt>
+         *     <dt>last_access >= YYYY-MM-DD</dt>
+         *     <dt>last_access < YYYY-MM-DD</dt>
+         *         <dd>Only collections accessed before or after the given date</dd>
+         *     <dt>created_at < YYYY-MM-DD</dt>
+         *     <dt>created_at <= YYYY-MM-DD</dt>
+         *     <dt>created_at <= YYYY-MM-DD</dt>
+         *     <dt>created_at = YYYY-MM-DD</dt>
+         *     <dt>created_at >= YYYY-MM-DD</dt>
+         *     <dt>created_at < YYYY-MM-DD</dt>
+         *         <dd>Only collections created before or after the given date</dd>
+         *     </dl>
+         *
+         *     The result can also be limited by including the `mapped_collection_id`
+         *     query parameter. This limits the response to guest collections which have
+         *     been created using the specified mapped collection.
+         *
+         *     Normally, only public collection configuration policy data is included in
+         *     the response. If the query parameter `include=private_policies` is passed
+         *     to this API, and the caller has an administrator role on this collection,
+         *     the response will include all private policies for the collection as well.
+         *
+         */
+        get: operations["listCollections"];
+        put?: never;
+        /**
+         * Create a collection
+         * @description This is used to create either a mapped or a guest collection. When created,
+         *     a "collection:administrator" role for that collection will be created using
+         *     the caller's identity.
+         *
+         *     The collection is assigned a unique DNS name. For guest collections, this
+         *     DNS name begins with "g-". By default, for mapped collections this name
+         *     begins with "m-", but a user with an "endpoint:administrator" role may
+         *     assign a custom domain name for a mapped collection.
+         *
+         *     In order to create a guest collection, the caller must have an identity
+         *     that matches the Storage Gateway policies.
+         *
+         *     In order to create a mapped collection, the caller must have an
+         *     "endpoint:administrator" or "endpoint:owner" role.
+         *
+         */
+        post: operations["postCollection"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{collection_id}/owner_string": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set advertised owner of collection
+         * @description Update the advertised owner string of the collection
+         *
+         *     Modify the collection's advertised owner to match the username of one of
+         *     the caller's linked identities.  The identity must have an administrator
+         *     role on the collection.
+         *
+         */
+        put: operations["putCollectionOwnerString"];
+        post?: never;
+        /**
+         * Reset advertised owner of collection
+         * @description Reset the advertised owner string of the collection to the endpoint's client_id.
+         *
+         */
+        delete: operations["deleteCollectionOwnerString"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{collection_id}/domain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get custom domain for a collection
+         * @description Get the custom domain document associated with this collection.
+         *
+         *     This requires an `administrator` role on the Endpoint
+         *
+         */
+        get: operations["getCollectionDomain"];
+        /**
+         * Set custom domain for a collection
+         * @description Register a new custom domain and certificate to to be used to serve
+         *     this collection.
+         *
+         *     The domain is used for the collection. If this is a mapped collection
+         *     and the `wildcard` property is set to true, then all all guest collections
+         *     associated with this collection that do not have a custom domain will be
+         *     updated to use subdomains of that domain. Otherwise, only this collection
+         *     will use that domain.
+         *
+         *     This requires an `administrator` role on the Endpoint
+         *
+         */
+        put: operations["putCollectionDomain"];
+        post?: never;
+        /**
+         * Delete custom domain for a collection
+         * @description Delete the custom collection domain.
+         *
+         *     If this is a mapped collection, this will cause the collection to revert to
+         *     a subdomain of the endpoint's domain (if it is wildcard domain) or a
+         *     subdomain of the endpoint's data.globus.org domain. If this mapped collection
+         *     has a wildcard domain when this is called, then all guest collections without
+         *     custom domains will have their domains changed as well.
+         *
+         *     If this is a guest collection, and the mapped collection it was created from
+         *     has a custom wildcard domain, then this collection will become a subdomain
+         *     of that domain; otherwise it will revert to a subdomain of either the
+         *     endpoint's domain (if it is a wildcard domain) or a subdomain of the endpoint's
+         *     data.globus.org domain.
+         *
+         *     This requires an `administrator` role on the Endpoint.
+         *
+         */
+        delete: operations["deleteCollectionDomain"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{collection_id}/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Check a collection for configuration problems
+         * @description Check the configuration of a collection for configuration problems. Returns
+         *     a list of configuration error details.
+         *
+         *     This operation requires the caller to have an endpoint owner or
+         *     administrator role, or a collection administrator role.
+         *
+         */
+        get: operations["checkCollection"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{collection_id}/owner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set collection owner
+         * @description Assign a new identity to act as the mapped collection owner. Caller must have
+         *     an endpoint admin or owner role.
+         *
+         *     - This is only allowed for mapped collections
+         *     - Owner ID can not be the endpoint client ID
+         *
+         */
+        put: operations["setCollectionOwner"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{collection_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get information about a collection
+         * @description This operation requires either the endpoint to have the `public` property
+         *     set to `true` or the caller to have a role that allows viewing this
+         *     Endpoint.  Some property visibility is limited for users who do not have an
+         *     `administrator` role.
+         *
+         *     Normally, only public collection configuration policy data is included in
+         *     the response. If the query parameter `include=private_policies` is passed
+         *     to this API, and the caller has an administrator role on this collection,
+         *     the response will include all private policies for the collection as well.
+         *
+         */
+        get: operations["getCollection"];
+        /**
+         * Update a collection
+         * @description Update a collection, completely replacing its definition with the new
+         *     document. It returns a document containing the collection after the
+         *     update has been applied.
+         *
+         */
+        put: operations["putCollection"];
+        post?: never;
+        /**
+         * Delete a collection
+         * @description Deletes a collection owned by the caller or an endpoint administrator.
+         *     If the collection has the delete_protection property set to true, the
+         *     collection can not be deleted.
+         *
+         *     When a collection is deleted, all collection-specific roles and
+         *     sharing_policies are also deleted.
+         *
+         *     If a mapped collection is deleted, then all guest collections and roles
+         *     associated them are also deleted.
+         *
+         */
+        delete: operations["deleteCollection"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a collection
+         * @description Updates a collection, changing only the properties included in the input
+         *     document. It optionally returns a document containing the document after
+         *     the change is applied.  Items explicitly set to null in the input are
+         *     removed from the collection document.
+         *
+         */
+        patch: operations["patchCollection"];
+        trace?: never;
+    };
+    "/api/endpoint/subscription_id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set the endpoint subscription id
+         * @description Change the subscription_id of this endpoint. Because subscription
+         *     is enforcement is handled in a separate service than GCS and an
+         *     organization's subscription manager may not be the administrator
+         *     of the endpoint, this API has allows for both role-based
+         *     authorization and subscription manager based authorization.
+         *
+         *     The authorization allows the following:
+         *
+         *     <dl>
+         *     <dt>Caller has a role but is not subscription manager</dt>
+         *     <dd>Remove an existing subscription from an endpoint, even if the
+         *         caller is not a manager for that subscription.</dd>
+         *
+         *     <dt>Caller does not have a role but is a subscription manager</dt>
+         *     <dd>Set the subscription_id to a subscription they manage on a
+         *         currently-unmanaged endpoint or remove the subscription_id from
+         *         the endpoint if it is one that they managed.</dd>
+         *
+         *     <dt>Caller has a role and is a subscription manager</dt>
+         *     <dd>Set the subscription_id to a subscription they manage on an endpoint
+         *         even if it is currently managed by a subscription that the caller is
+         *         not a manager of.</dd>
+         *     </dl>
+         *
+         */
+        put: operations["putEndpointSubscriptionId"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/endpoint/owner_string": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set endpoint owner string
+         * @description Modify the endpoint's advertised owner to match the username of one of the
+         *     caller's linked identities.  The identity must have an administrator role
+         *     on the endpoint.
+         *
+         */
+        put: operations["putEndpointOwnerString"];
+        post?: never;
+        /**
+         * Reset advertised owner string
+         * @description Reset the endpoint's advertised owner to the client_id of the endpoint.
+         *
+         */
+        delete: operations["deleteEndpointOwnerString"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/endpoint/domain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get endpoint domain
+         * @description Get the custom domain document associated with this endpoint.
+         *
+         *     This requires an `administrator` role on the Endpoint.
+         *
+         */
+        get: operations["getEndpointDomain"];
+        /**
+         * Set endpoint domain
+         * @description Register a new custom domain and certificate to to be used to serve
+         *     the endpoint or collection.
+         *
+         *     The domain is used for the endpoint itself. If the `wildcard`
+         *     property is set to true, then all all collections associated
+         *     with that endpoint that do not have a custom domain will be
+         *     updated to use subdomains of that domain. Otherwise, only the
+         *     endpoint will use that domain.
+         *
+         */
+        put: operations["putEndpointDomain"];
+        post?: never;
+        /**
+         * Delete endpoint domain
+         * @description Delete the custom endpoint domain. This will cause the endpoint
+         *     to revert to using a data.globus.org domain for the GCS Manager
+         *     and any collections which do not have custom domains associated
+         *     with them.
+         *
+         *     This requires an `administrator` role on the Endpoint.
+         *
+         */
+        delete: operations["deleteEndpointDomain"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/endpoint/owner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set endpoint owner
+         * @description Assign a new identity to act as the endpoint owner.
+         *
+         */
+        put: operations["putEndpointOwner"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/endpoint": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get endpoint definition
+         * @description Get the endpoint.
+         *
+         */
+        get: operations["getEndpoint"];
+        /**
+         * Update an endpoint
+         * @description Update the endpoint document, replacing all properties with those in the
+         *     input. This operation optionally returns the Endpoint after the update if
+         *     the include=endpoint query parameter is passed to this operation.
+         *
+         */
+        put: operations["putEndpoint"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update an endpoint
+         * @description Update the Endpoint document, changing only the properties included in the
+         *     input. Items explicitly set to null in the input are removed from the
+         *     endpoint document. This operation optionally returns the endpoint after
+         *     applying the changes in the input if the include=endpoint query parameter
+         *     is passed to this operation.
+         *
+         */
+        patch: operations["patchEndpoint"];
+        trace?: never;
+    };
+    "/api/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get GCS service information
+         * @description Returns information about the GCS Manager service for this endpoint, as
+         *     well as additional features such as connectors that it provides as
+         *     extensions to the API defined in this document.
+         *
+         *     This operation can be performed without an `Authorization` header.
+         *
+         */
+        get: operations["getInfo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/nodes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List endpoint nodes
+         * @description Get the endpoint's list of nodes.
+         *
+         *     This operation requires either the endpoint to have the `public` property
+         *     set to true or the caller to have a role that allows viewing this endpoint
+         *     or a collection on it.
+         *
+         */
+        get: operations["listNodes"];
+        put?: never;
+        /**
+         * Create a new node
+         * @description Create a new node to describe a host which is providing service
+         *     for this endpoint. This adds the node's IP address to the DNS record
+         *     for this endpoint's GCS Manager and for all collections.
+         *
+         *     On success returns a copy of the created Node with the system generated id
+         *     added.
+         *
+         */
+        post: operations["postNode"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/nodes/{node_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get node
+         * @description Get information about one of the endpoint's node.
+         *
+         *     This operation requires either the endpoint to have the public property set
+         *     to true or the caller to have a role that allows viewing this Endpoint or a
+         *     Collection on it.
+         *
+         */
+        get: operations["getNode"];
+        /**
+         * Update a node
+         * @description Update a node, replacing all properties with those in the input.  This
+         *     operation optionally returns the node's definition after the update if the
+         *     `include=node` query parameter is passed to this operation.
+         *
+         */
+        put: operations["putNode"];
+        post?: never;
+        /**
+         * Delete a node
+         * @description Delete the `Node` document for the given node.
+         *
+         */
+        delete: operations["deleteNode"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a node
+         * @description Update a node, changing only the properties included in the input document.
+         *     Items explicitly set to null in the input are removed from the Node
+         *     document. This operation optionally returns the node definition after
+         *     applying the changes in the input if the `include=node` query parameter is
+         *     passed to this operation.
+         *
+         */
+        patch: operations["patchNode"];
+        trace?: never;
+    };
+    "/api/roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List roles
+         * @description Get the endpoint's or a collection's list of role associations.
+         *
+         *     If the `collection_id` query parameter is passed to this operation, then
+         *     the roles related to that collection are returned. Otherwise, this
+         *     operation returns endpoint roles.
+         *
+         *     The `include` parameter determines whether this operation returns all roles
+         *     relevant to the resource or only those that the caller has.
+         *
+         *     To obtain information about *all* roles, the caller must pass the
+         *     "all_roles" value as the value of the "include" parameter.  This requires
+         *     the "administrator" role for the endpoint Or Collection the role is
+         *     associated with.
+         *
+         */
+        get: operations["listRoles"];
+        put?: never;
+        /**
+         * Create a role
+         * @description Assign a role to an identity or group for the endpoint or a collection.
+         *
+         *     See
+         *     https://docs.globus.org/globus-connect-server/v5.4/reference/endpoint/role/[endpoint roles]
+         *     and
+         *     https://docs.globus.org/globus-connect-server/v5.4/reference/collection/role/[collection
+         *     roles] for description of the available roles.
+         *
+         *     To assign a role to a collection, include the collection's ID in the
+         *     collection property of the input document.
+         *
+         *
+         *     When creating an endpoint role, the caller must have then
+         *     `endpoint:administrator` role assigned to one of their identities.
+         *
+         *     When creating a collection role for a *mapped* collection, the caller must
+         *     have either the `endpoint:administrator` role or the
+         *     `collection:administrator` role assigned for that collection.
+         *
+         *     When creating a collection role for a *guest* collection, the caller must have
+         *     a `collection:administrator` role on the collection.
+         *
+         *     On success returns a copy of the created role with the system generated id
+         *     added.
+         *
+         */
+        post: operations["postRoles"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/roles/{role_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a role
+         * @description Get one of the role assignments on this endpoint.
+         *
+         */
+        get: operations["getRole"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a role
+         * @description Delete one of the endpoint or collection roles on this endpoint.
+         *
+         *     To delete an endpoint role, the caller must have an `endpoint:administrator`
+         *     role.
+         *
+         *     To delete a *mapped* collection role, the caller must have one of
+         *     `endpoint:administrator` or `collection:administrator` role for the
+         *     collection.
+         *
+         *     To delete a *guest* collection role, the caller must have one of
+         *     `endpoint:administrator`, `collection:administrator` role for the
+         *     guest collection, or `collection:administrator` for the mapped collection
+         *     the guest collection was created on.
+         *
+         *     The `endpoint:owner`, or the `collection:administrator` role for the creator
+         *     of a collection may not be deleted using this API.
+         *
+         */
+        delete: operations["deleteRole"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sharing_policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List sharing policies
+         * @description List the sharing policies for a mapped collection.  This may return a
+         *     paginated result; the `marker` and `page_size` query parameters can be used
+         *     to obtain the next page of response data for the query.
+         *
+         *     If the `username` query parameter is passed to this function then only the
+         *     policies which are relevant to the given username are returned. This will
+         *     include policies where the **users** property is `null` or contains the
+         *     given username.
+         *
+         */
+        get: operations["listSharingPolicies"];
+        put?: never;
+        /**
+         * Create a sharing policy
+         * @description Create a new sharing policy document for a mapped collection.  This new
+         *     document will be added to the set of sharing policy documents for this
+         *     collection. The sharing policy documents which either have no user
+         *     constraint, or match the guest collection owner are used to determine which
+         *     paths are available to be shared.
+         *
+         *     This returns the policy document with the "id" field populated with the
+         *     assigned ID of this policy.
+         *
+         */
+        post: operations["postSharingPolicy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sharing_policies/{sharing_policy_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a sharing policy
+         * @description Get a sharing policy.
+         *
+         */
+        get: operations["getSharingPolicy"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a sharing policy
+         * @description Delete a sharing policy.
+         *
+         *     This may alter the behavior of existing guest collections, if the policies
+         *     change the visible parts of the storage gateway's virtual file system for
+         *     the guest collection creator.
+         *
+         */
+        delete: operations["deleteSharingPolicy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/storage_gateways": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List storage gateways
+         * @description List the storage gateways on an endpoint.
+         *
+         *     The `include` query parameter controls what additional information is
+         *     included in the `Result` document.  This operation requires either the
+         *     endpoint to have the `public` property set to true, the caller to have a
+         *     role that allows viewing this Endpoint, the user to have an identity which
+         *     is allowed by the individual Storage Gateway policies, or an identity which
+         *     has a permission for a collection created on this Storage Gateway.
+         *
+         */
+        get: operations["listStorageGateways"];
+        put?: never;
+        /**
+         * Create a storage gateway
+         * @description Create a storage gateway on an endpoint. On success, this operation returns
+         *     a copy of the created storage gateway with the system generated id added.
+         *
+         */
+        post: operations["postStorageGateway"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/storage_gateways/{storage_gateway_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a storage gateway
+         * @description Get a storage gateway's definition.
+         *
+         *     The `include` query parameter controls what additional information is
+         *     included in the `Result` document. This operation requires either the
+         *     endpoint to have the `public` property set to true, the caller to have a
+         *     role that allows viewing this Endpoint, the user to have an identity which
+         *     is allowed by the individual storage gateway policies, or an identity which
+         *     has a permission for a collection created on this storage gateway.
+         *
+         */
+        get: operations["getStorageGateway"];
+        /**
+         * Update a storage gateway
+         * @description Update a storage gateway, completely replacing its definition with the new
+         *     document. It returns a document containing the storage gateway after the
+         *     update has been applied.
+         *
+         *     This operation may return a Conflict error if any collections exist which
+         *     would be not be consistent with the change in Storage Gateway policies.
+         *
+         *     The `high_assurance` property cannot be changed.
+         *
+         */
+        put: operations["putStorageGateway"];
+        post?: never;
+        /**
+         * Delete a storage gateway
+         * @description Delete a storage gateway.
+         *
+         */
+        delete: operations["deleteStorageGateway"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a storage gateway
+         * @description Update a storage gateway, change only the properties included in the input
+         *     document. It returns a document containing the storage gateway after the
+         *     changes have been applied. Items explicitly set to null in the input are
+         *     removed from the storage gateway.
+         *
+         *     Some properties are immutable, in general, the `id`,  `connector_id`, and
+         *     `high_assurance` properties cannot be changed, though storage
+         *     gateways may enforce additional restrictions.
+         *
+         *     This operation may return a Conflict error if any collections exist which
+         *     would be not be consistent with the change in Storage Gateway policies.
+         *
+         */
+        patch: operations["patchStorageGateway"];
+        trace?: never;
+    };
+    "/api/user_credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List user credentials
+         * @description The caller may only retrieve User Credentials which were created by an
+         *     identity in the caller's identity set unless they are an administrator. If
+         *     the endpoint is not public, returns ForbiddenError if the user has no
+         *     credentials
+         *
+         */
+        get: operations["listUserCredentials"];
+        put?: never;
+        /**
+         * Create a user credential
+         * @description Create a user credential on a storage gateway. This is required
+         *     for some connectors that require a local user name or other
+         *     credential information to access the storage system. See the
+         *     connector-specific documentation for details on what is needed.
+         *
+         *     The caller is authorized based on the StorageGateway identity
+         *     policies, so users with no assigned roles on the endpoint may
+         *     be permitted to access this operation.
+         *
+         */
+        post: operations["postUserCredential"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/user_credentials/{user_credential_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a user credential
+         * @description Get a user credential.
+         *
+         *     The caller must have the identity_id of the user credential
+         *     in its identity set.
+         *
+         */
+        get: operations["getUserCredential"];
+        /**
+         * Update a user credential
+         * @description Update a user credential on a storage gateway. This is required
+         *     for some connectors that require a local user name or other
+         *     credential information to access the storage system. See the
+         *     connector-specific documentation for details on what is needed.
+         *
+         *     The caller must have the identity_id of the user credential
+         *     in its identity set.
+         *
+         */
+        put: operations["putUserCredential"];
+        post?: never;
+        /**
+         * Delete a user credential
+         * @description Delete a user credential.
+         *
+         *     The caller must have the identity_id of the user credential in its identity
+         *     set.
+         *
+         */
+        delete: operations["deleteUserCredential"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a user credential
+         * @description Update a user credential on a storage gateway. This is required
+         *     for some connectors that require a local user name or other
+         *     credential information to access the storage system. See the
+         *     connector-specific documentation for details on what is needed.
+         *
+         *     The caller must have the identity_id of the user credential
+         *     in its identity set.
+         *
+         */
+        patch: operations["patchUserCredential"];
+        trace?: never;
+    };
+    "/api/v1/authcallback_google": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OAuth callback
+         * @deprecated
+         */
+        get: operations["getAuthcallbackGoogle"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/user_credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a user credential
+         * @description Create a user credential on a Storage Gateway. This
+         *     initiates a flow to an OAuth service
+         *     to authenticate the user and generate an authentication
+         *     token to allow access to a storage system.
+         *
+         */
+        post: operations["postUserCredentials"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/authclicomplete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OAuth callback for CLI apps
+         * @description Landing page for auth flow completion, suitable for use with a
+         *     non-web application that uses a browser to complete the flow.
+         *
+         */
+        get: operations["getAuthclicomplete"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/authcallback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** OAuth callback */
+        get: operations["getAuthcallback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /** OAuthUserCredentialForm */
+        OAuthUserCredentialForm: {
+            /** @description Unused */
+            access_token?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity id that this credential is associated with
+             */
+            identity_id: string;
+            /** @description Mapped account username on the storage gateway */
+            login_hint?: string;
+            /** @description URL to redirect to once the credential registration flow is complete. This should be a maximum of 220 characters to avoid conflicts with connector state limits. */
+            redirect_uri: string;
+            /**
+             * Format: uuid
+             * @description Storage gateway to associate the credential with
+             */
+            storage_gateway: string;
+        };
+        /**
+         * Account_1_0_0
+         * @description User account information for a particular Storage Gateway.
+         */
+        Account_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default account#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "account#1.0.0";
+            /**
+             * Format: uuid
+             * @description Globus Auth identity which maps to this account
+             */
+            identity_id?: string;
+            /**
+             * Format: uuid
+             * @description Storage Gateway for which this account is valid.
+             */
+            storage_gateway_id?: string;
+            /** @description Connector-specific local username */
+            username?: string;
+        };
+        /**
+         * Batch_1_0_0
+         * @description The Batch data type is used to specify multiple objects to operate
+         *     on via a single REST API call.
+         *
+         */
+        Batch_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default batch#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "batch#1.0.0";
+            /** @description List of object IDs to operate on */
+            ids?: string[];
+        };
+        /**
+         * AuthenticationTimeout_1_0_0
+         * @description Error details when a user must reauthenticate an identity
+         *     in order to perform this operation.
+         *
+         */
+        AuthenticationTimeout_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default authentication_timeout#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "authentication_timeout#1.0.0";
+            /** @description Boolean flag indicating whether the new authentication
+             *     must be done within the same auth session as the
+             *     application making the request.
+             *      */
+            high_assurance?: boolean;
+            /** @description List of identities that would have otherwise been
+             *     authorized except that the authentication has timed out.
+             *      */
+            identities?: string[];
+        };
+        /**
+         * AuthenticationTimeout_1_1_0
+         * @description Error details when a user must reauthenticate an identity
+         *     in order to perform this operation.
+         *
+         *     Version 1.1.0 adds the require_mfa property.
+         *
+         */
+        AuthenticationTimeout_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default authentication_timeout#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "authentication_timeout#1.1.0";
+            /** @description Boolean flag indicating whether the new authentication
+             *     must be done within the same auth session as the
+             *     application making the request.
+             *      */
+            high_assurance?: boolean;
+            /** @description List of identities that would have otherwise been
+             *     authorized except that the authentication has timed out.
+             *      */
+            identities?: string[];
+            /** @description Flag indicating that multi-factor authentication is required.
+             *     Only occurs on high assurance storage gateways.
+             *      */
+            require_mfa?: boolean;
+        };
+        /**
+         * CheckResult_1_0_0
+         * @description Consistency check information
+         */
+        CheckResult_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default check_result#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "check_result#1.0.0";
+            /** @description Error details */
+            error?: Record<string, unknown> | null;
+            /**
+             * Format: uuid
+             * @description ID of the object that was checked
+             */
+            id?: string;
+            /** @description Message describing the error */
+            message?: string;
+        };
+        /**
+         * Domain_1_0_0
+         * @description Custom domain description
+         *
+         */
+        Domain_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default domain#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "domain#1.0.0";
+            /** @description PEM-Encoded X.509 certificate for this domain */
+            certificate?: string | null;
+            /** @description PEM-Encoded X.509 certificate chain for this domain. Only needed if
+             *     there are intermediate certificates that must also be sent to
+             *     clients to allow them to verify the certificate.
+             *      */
+            certificate_chain?: string | null;
+            /** @description Path to a file containing the X.509 certificate chain for this
+             *     domain. This file path must contain a sequence of valid
+             *     certificate and be present on each data transfer node.
+             *      */
+            certificate_chain_path?: string | null;
+            /** @description Path to a file containing the X.509 certificate for this domain.
+             *     This file path must contain a valid certificate and be present on
+             *     each data transfer node.
+             *      */
+            certificate_path?: string | null;
+            /** @description Domain name */
+            domain_name: string;
+            /** @description PEM-Encoded private key for the certificate */
+            private_key?: string | null;
+            /** @description Path to a file containing the private key for this domain. This
+             *     file path must contain a valid key and be present on each data
+             *     transfer node.
+             *      */
+            private_key_path?: string | null;
+            /** @description Flag indicating whether this is a wildcard domain or not.
+             *
+             *     When setting a custom domain for a mapped collection, the domain
+             *     may optionally be a wildcard domain. If it is a wildcard domain,
+             *     the guest collections will be created as subdomains of the mapped
+             *     collection domain; if not, guest collections will be created as
+             *     subdomains of the endpoint domain.
+             *      */
+            wildcard: boolean;
+        };
+        /**
+         * PathRestrictions_1_0_0
+         * @description This object represents the path restrictions for a storage gateway
+         *     or a sharing path restrictions for a mapped collection.
+         *
+         *     The values of each of the path lists in this object are interpreted using
+         *     the POSIX pattern matching notation as described in
+         *     https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html[fnmatch(3)]
+         *     with flags set to `0` with additional support for some special
+         *     user-specific value interpolation:
+         *
+         *     `~`, `$HOME`::
+         *
+         *     The user's home directory if the storage gateway supports such a concept,
+         *     `/` otherwise
+         *
+         *     `$USER`::
+         *
+         *     The effective Storage Gateway-specific username that is being used for data
+         *     access. For a Guest Collection, this is the username of the identity that
+         *     created the Guest Collection.
+         *
+         *     These restrictions are evaluated at every data access. When
+         *     evaluating restrictions, the user-specific interpolation is
+         *     applied before the file name matching is evaluated.
+         *
+         *     Globus Connect Server evaluates its path restrictions from
+         *     longest leading expression match to shortest. When pattern
+         *     matching characters are present, they are considered as a lower
+         *     priority match than a literal character, with more specific
+         *     pattern characters given precedence. The precedence is thus
+         *     literal character, bracket expression, `?` (single-character
+         *     wildcard), `*` (wildcard).
+         *
+         *     If multiple path restrictions apply, all matches are applied
+         *     from longest to shortest, with the following rules for
+         *     overriding values:
+         *
+         *     ### Path Restriction Override Precedence
+         *     ++++
+         *     <table>
+         *       <tr>
+         *         <th>longer restriction</th>
+         *         <th>shorter restriction</th>
+         *         <th>result</th>
+         *       </tr>
+         *     <tr>
+         *     <td> <pre>read_write</pre>   </td><td> <pre>read</pre>          </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read_write</pre>   </td><td> <pre>none</pre>          </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read</pre>         </td><td> <pre>read_write</pre>    </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read</pre>         </td><td> <pre>none</pre>          </td><td> <pre>read</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>none</pre>         </td><td> <pre>read_write</pre>    </td><td> <pre>none</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>none</pre>         </td><td> <pre>read</pre>          </td><td> <pre>none</pre></td>
+         *     </tr>
+         *     </table>
+         *     ++++
+         *
+         *
+         */
+        PathRestrictions_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default path_restrictions#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "path_restrictions#1.0.0";
+            /** @description List of paths which are denied any access */
+            none?: string[];
+            /** @description List of paths which are allowed read-only access */
+            read?: string[];
+            /** @description List of paths which are allowed read-write access */
+            read_write?: string[];
+        };
+        /**
+         * PathRestrictions
+         * @description This object represents the path restrictions for a storage gateway
+         *     or a sharing path restrictions for a mapped collection.
+         *
+         *     The values of each of the path lists in this object are interpreted using
+         *     the POSIX pattern matching notation as described in
+         *     https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html[fnmatch(3)]
+         *     with flags set to `0` with additional support for some special
+         *     user-specific value interpolation:
+         *
+         *     `~`, `$HOME`::
+         *
+         *     The user's home directory if the storage gateway supports such a concept,
+         *     `/` otherwise
+         *
+         *     `$USER`::
+         *
+         *     The effective Storage Gateway-specific username that is being used for data
+         *     access. For a Guest Collection, this is the username of the identity that
+         *     created the Guest Collection.
+         *
+         *     These restrictions are evaluated at every data access. When
+         *     evaluating restrictions, the user-specific interpolation is
+         *     applied before the file name matching is evaluated.
+         *
+         *     Globus Connect Server evaluates its path restrictions from
+         *     longest leading expression match to shortest. When pattern
+         *     matching characters are present, they are considered as a lower
+         *     priority match than a literal character, with more specific
+         *     pattern characters given precedence. The precedence is thus
+         *     literal character, bracket expression, `?` (single-character
+         *     wildcard), `*` (wildcard).
+         *
+         *     If multiple path restrictions apply, all matches are applied
+         *     from longest to shortest, with the following rules for
+         *     overriding values:
+         *
+         *     ### Path Restriction Override Precedence
+         *     ++++
+         *     <table>
+         *       <tr>
+         *         <th>longer restriction</th>
+         *         <th>shorter restriction</th>
+         *         <th>result</th>
+         *       </tr>
+         *     <tr>
+         *     <td> <pre>read_write</pre>   </td><td> <pre>read</pre>          </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read_write</pre>   </td><td> <pre>none</pre>          </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read</pre>         </td><td> <pre>read_write</pre>    </td><td> <pre>read_write</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>read</pre>         </td><td> <pre>none</pre>          </td><td> <pre>read</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>none</pre>         </td><td> <pre>read_write</pre>    </td><td> <pre>none</pre></td>
+         *     </tr>
+         *     <tr>
+         *     <td> <pre>none</pre>         </td><td> <pre>read</pre>          </td><td> <pre>none</pre></td>
+         *     </tr>
+         *     </table>
+         *     ++++
+         *
+         *
+         */
+        PathRestrictions: components["schemas"]["PathRestrictions_1_0_0"];
+        /**
+         * SharingPolicy_1_0_0
+         * @description Sharing policies for a mapped collection.
+         *
+         *     This document type allows endpoint and collection administrators to
+         *     optionally constrain sharing path policies for particular users. The
+         *     **sharing_restrict_paths** property has a similar meaning to that of the
+         *     **sharing_restrict_paths** in the collection document; however, it is in
+         *     effect only for specific users.
+         *
+         *     If the **users** property is null, then the restriction applies to all
+         *     users. If it is non-null, then this restriction applies only to accounts
+         *     which have been mapped to the enumerated storage gateway user accounts.
+         *
+         *     Multiple sharing policies can be defined for a mapped collection.  When a
+         *     guest collection is created or accessed, only the policies relevant to the
+         *     user which created the account are enforced.
+         *
+         */
+        SharingPolicy_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default sharing_policy#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "sharing_policy#1.0.0";
+            /**
+             * Format: uuid
+             * @description Id of the mapped collection which this policy is associated with
+             */
+            collection_id: string;
+            /**
+             * Format: uuid
+             * @description Unique id for this sharing policy
+             */
+            id?: string;
+            /** @description Restrictions on which paths may be shared in guest collections
+             *     related to this mapped collection. These paths are relative to the
+             *     root_path property of the mapped collection.
+             *      */
+            sharing_restrict_paths: components["schemas"]["PathRestrictions"];
+            /** @description List of local user accounts that this policy applies to. If omitted
+             *     or null, this restriction applies to all local user accounts.
+             *      */
+            users?: string[];
+        };
+        /**
+         * Collection_1_0_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         */
+        Collection_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.0.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+        };
+        /**
+         * Collection_1_1_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         */
+        Collection_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.1.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_2_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         */
+        Collection_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.2.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Domain
+         * @description Custom domain description
+         *
+         */
+        Domain: components["schemas"]["Domain_1_0_0"];
+        /**
+         * Collection_1_3_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         */
+        Collection_1_3_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.3.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.3.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_4_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         */
+        Collection_1_4_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.4.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.4.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_5_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         */
+        Collection_1_5_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.5.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.5.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_6_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         */
+        Collection_1_6_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.6.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.6.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 64 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_7_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         */
+        Collection_1_7_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.7.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.7.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_8_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         */
+        Collection_1_8_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.8.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.8.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_9_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         */
+        Collection_1_9_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.9.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.9.0";
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /**
+             * Format: date
+             * @description Date on which this collection was created
+             */
+            readonly created_at?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /**
+             * Format: date
+             * @description Date on which this collection was last accessed
+             */
+            readonly last_access?: string | null;
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_10_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         *     Version 1.10.0 adds the acl_expiration_mins property to HA mapped collections.
+         *
+         */
+        Collection_1_10_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.10.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.10.0";
+            /** @description Length of time that guest collection permissions are valid. Only settable on HA mapped collections and used by the guest collections attached to it. Set to null to delete any previously set value. */
+            acl_expiration_mins?: number | null;
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /**
+             * Format: date
+             * @description Date on which this collection was created
+             */
+            readonly created_at?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /**
+             * Format: date
+             * @description Date on which this collection was last accessed
+             */
+            readonly last_access?: string | null;
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_11_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         *     Version 1.10.0 adds the acl_expiration_mins property to HA mapped collections.
+         *
+         *     Version 1.11.0 adds the acl_expiration_mins property to HA guest collection.
+         *
+         */
+        Collection_1_11_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.11.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.11.0";
+            /** @description Length of time that guest collection permissions are valid. Only settable on HA guest collections and HA mapped collections and used by guest collections attached to it. When set on both the mapped and guest collections, the lessor value is in effect. Set to null to delete any previously set value. */
+            acl_expiration_mins?: number | null;
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /**
+             * Format: date
+             * @description Date on which this collection was created
+             */
+            readonly created_at?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /**
+             * Format: date
+             * @description Date on which this collection was last accessed
+             */
+            readonly last_access?: string | null;
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_12_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         *     Version 1.10.0 adds the acl_expiration_mins property to HA mapped collections.
+         *
+         *     Version 1.11.0 adds the acl_expiration_mins property to HA guest collection.
+         *
+         *     Version 1.12.0 adds the restrict_transfers_to_high_assurance property to HA
+         *     collections.
+         *
+         */
+        Collection_1_12_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.12.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.12.0";
+            /** @description Length of time that guest collection permissions are valid. Only settable on HA guest collections and HA mapped collections and used by guest collections attached to it. When set on both the mapped and guest collections, the lessor value is in effect. Set to null to delete any previously set value. */
+            acl_expiration_mins?: number | null;
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /**
+             * Format: date
+             * @description Date on which this collection was created
+             */
+            readonly created_at?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /**
+             * Format: date
+             * @description Date on which this collection was last accessed
+             */
+            readonly last_access?: string | null;
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /**
+             * @description Flag indicating whether all data transfers to and from this
+             *     collection require the remote collection be HA. This can only be
+             *     assigned on high assurance mapped collections. High assurance
+             *     guest collections inherit the restriction from their associated
+             *     mapped collections. This may be set to null to disable this feature.
+             *
+             *     If a restriction is in place for a collection, then HTTPS access to
+             *     it is disabled.
+             *
+             * @enum {string|null}
+             */
+            restrict_transfers_to_high_assurance?: "inbound" | "outbound" | "all" | null;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * Collection_1_13_0
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         *     Version 1.10.0 adds the acl_expiration_mins property to HA mapped collections.
+         *
+         *     Version 1.11.0 adds the acl_expiration_mins property to HA guest collection.
+         *
+         *     Version 1.12.0 adds the restrict_transfers_to_high_assurance property to HA
+         *     collections.
+         *
+         *     Version 1.13.0 adds the auto_delete_timeout property to mapped collections
+         *     and the skip_auto_delete property to guest collections.
+         *
+         */
+        Collection_1_13_0: {
+            /**
+             * @description Type of this document
+             * @default collection#1.13.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection#1.13.0";
+            /** @description Length of time that guest collection permissions are valid. Only settable on HA guest collections and HA mapped collections and used by guest collections attached to it. When set on both the mapped and guest collections, the lessor value is in effect. Set to null to delete any previously set value. */
+            acl_expiration_mins?: number | null;
+            /** @description Flag indicating if this Collection allows users to create guest
+             *     collections on it. This is always false if this is a guest
+             *     collection. If this is changed to false on a mapped collection with
+             *     associated guest collections, those collections will no longer be
+             *     accessible.
+             *      */
+            allow_guest_collections?: boolean;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated in a session to access this storage gateway.
+             *      */
+            readonly authentication_timeout_mins?: number;
+            /** @description Number of days before unused guest collections will be automatically
+             *     deleted. Only settable on mapped collections. Values must be an integer
+             *     greater than 0. Set to null to disable automatic guest collection deletion
+             *     for the mapped collection. Defaults to disabled.
+             *      */
+            auto_delete_timeout?: number | null;
+            /** @description Path to be interpreted as the base path when creating a new
+             *     collection. It is interpreted differently depending on the
+             *     collection type being created. For a mapped collection, this is an
+             *     absolute path on the storage system named by the
+             *     storage_gateway_id.  For a guest collection, this is a relative
+             *     path relative to the value of the `root_path` attribute on the
+             *     mapped collection with the same Id as the `mapped_collection_id`
+             *     property.  This may not be changed once the collection is created.
+             *
+             *     Support for `~` was added in API version 1.21.0.
+             *      */
+            collection_base_path: string;
+            /**
+             * @description Type of collection. A `mapped` collection requires an account on
+             *     the system to access the administrator-defined collection. A
+             *     `guest` collection allows users to share access to their data on a
+             *     Storage Gateway by registering a credential with the GCS Manager.
+             *
+             * @enum {string}
+             */
+            collection_type: "mapped" | "guest";
+            /**
+             * Format: uuid
+             * @description Id of the connector type that is used by this collection.
+             */
+            readonly connector_id?: string;
+            /** @description Email address of the support contact for this collection. This is visible
+             *     to end users so that they may contact your organization for support.
+             *      */
+            contact_email?: string | null;
+            /** @description Other non-email contact information for the collection, e.g.  phone and
+             *     mailing address. This is visible to end users for support.
+             *      */
+            contact_info?: string | null;
+            /**
+             * Format: date
+             * @description Date on which this collection was created
+             */
+            readonly created_at?: string | null;
+            /** @description Default directory when accessing the collection. This may include
+             *     the special string `$USER` which is evaluated at access time to be
+             *     the connector-specific username accessing the data.
+             *
+             *     If the collection is mapped collection with a
+             *     **collection_base_path** value of `/`, this value can also begin
+             *     with the values `/~/` and `$HOME`, which are replaced by the user's
+             *     home directory, or `/` if the connector does not support the
+             *     concept of a home directory.
+             *      */
+            default_directory?: string;
+            /** @description If set to true, this collection can not be deleted. This property
+             *     is available only on mapped collections. As of GCS 5.4.69, this is
+             *     true by default.
+             *      */
+            delete_protected?: boolean;
+            /** @description Flag indicating that this collection has been deleted */
+            readonly deleted?: boolean;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Optional. Unicode string, max 1024
+             *     characters, no new lines.
+             *      */
+            department?: string | null;
+            /** @description A description of the collection. */
+            description?: string | null;
+            /** @description Flag indicating if guest collections on this mapped collection
+             *     allow anonymous write permissions or not. This flag is always true for high
+             *     assurance collections. For non-high assurance mapped collections, the
+             *     default value is false.
+             *      */
+            disable_anonymous_writes?: boolean;
+            /** @description Flag indicating that this endpoint does not support computing
+             *     checksums, needed for the verify_checksum option of transfer.
+             *      */
+            disable_verify?: boolean;
+            /** @description Friendly name for the collection. Unicode string, max 128
+             *     characters, no new lines (`\r` or `\n`).
+             *      */
+            display_name: string;
+            domain?: components["schemas"]["Domain"];
+            /** @description DNS name of the virtual host serving this collection. For mapped
+             *     collections which do not have a custom domain, this may be specified as
+             *     part of the input document to create the collection, otherwise this is
+             *     a read-only property. When included in the input, the name is
+             *     restricted to be a subdomain of the endpoint, and the input name label
+             *     may not start with `m-` or `g-`.
+             *      */
+            domain_name?: string;
+            /** @description Boolean flag indicating whether this collection should support
+             *     HTTPS. This value can be set on mapped collections or guest
+             *     collections. However, it may not be set to true on a guest
+             *     collection if the value on the related mapped collection is false.
+             *      */
+            enable_https?: boolean;
+            /** @description Flag indicating whether all data transfers to and from this
+             *     collection are always encrypted.
+             *
+             *     __New in v5.4.17__: If a mapped collection forces encryption, all
+             *     of its guest collections must as well.  If this option is used on a
+             *     mapped collection, the value is propagated to its guest
+             *     collections.
+             *      */
+            force_encryption?: boolean;
+            /** @description Flag indicating that this endpoint requires computing checksums,
+             *     needed for the verify_checksum option of transfer.
+             *      */
+            force_verify?: boolean;
+            /**
+             * Format: uuid
+             * @description Authentication policy set on mapped collections and inherited by its
+             *     guest collections. During authorization, the authentication policy must
+             *     be satisfied before permissions are considered. Read-only on guest
+             *     collections. (**Added in API 1.15.0**)
+             *
+             */
+            guest_auth_policy_id?: string | null;
+            /** @description Flag indicating if this collection is created on a high assurance
+             *     Storage Gateway.
+             *      */
+            readonly high_assurance?: boolean;
+            /** @description HTTPS URL for the data on this collection. */
+            readonly https_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this collection. This is assigned
+             *     by the GCS manager when creating a collection.
+             *
+             */
+            readonly id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity to who acts as the owner of this collection.
+             *     This identity is an `administrator` on the collection.
+             *
+             */
+            identity_id?: string;
+            /** @description Link to a web page with more information about the collection */
+            info_link?: string | null;
+            /** @description List of search keywords for the
+             *     endpoint.  Optional. Unicode string, max 1024
+             *     characters total across all strings.
+             *      */
+            keywords?: string[];
+            /**
+             * Format: date
+             * @description Date on which this collection was last accessed
+             */
+            readonly last_access?: string | null;
+            /** @description URL of the GCS Manager API service for the endpoint hosting this
+             *     collection.
+             *      */
+            readonly manager_url?: string;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Mapped Collection which this guest collection is
+             *     associated with. This is set on creation and may not be changed.
+             *     For a Guest Collection, this must be set, and policies related
+             *     sharing (`allow_guest_collections`, `sharing_restrict_paths`) will
+             *     always reflect the values in the Mapped Collection definition and
+             *     may not be changed on this Guest Collection.
+             *
+             */
+            mapped_collection_id?: string;
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Optional to preserve backward compatibility, but will eventually be
+             *     required and all clients are encouraged to require users to specify
+             *     it.  Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Connector-specific collection policies */
+            policies?: components["schemas"]["S3CollectionPolicies_1_0_0"] | components["schemas"]["AzureBlobCollectionPolicies_1_0_0"] | components["schemas"]["BlackPearlCollectionPolicies_1_0_0"] | components["schemas"]["BoxCollectionPolicies_1_0_0"] | components["schemas"]["CephCollectionPolicies_1_0_0"] | components["schemas"]["DropboxCollectionPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"] | components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"] | components["schemas"]["HPSSCollectionPolicies_1_0_0"] | components["schemas"]["IrodsCollectionPolicies_1_0_0"] | components["schemas"]["OneDriveCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"] | components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+            /** @description Flag indicating whether this collection is visible to other Globus
+             *     users.
+             *      */
+            public: boolean;
+            /** @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only applies to high assurance storage gateways.
+             *      */
+            readonly require_mfa?: boolean;
+            /**
+             * @description Flag indicating whether all data transfers to and from this
+             *     collection require the remote collection be HA. This can only be
+             *     assigned on high assurance mapped collections. High assurance
+             *     guest collections inherit the restriction from their associated
+             *     mapped collections. This may be set to null to disable this feature.
+             *
+             *     If a restriction is in place for a collection, then HTTPS access to
+             *     it is disabled.
+             *
+             * @enum {string|null}
+             */
+            restrict_transfers_to_high_assurance?: "inbound" | "outbound" | "all" | null;
+            /** @description Absolute root path of the collection. All data access
+             *     is done relative to this path. On a guest collection,
+             *     this value is only visible if the caller has an
+             *     administrator role on both the guest collection and the
+             *     mapped collection it is created on.
+             *      */
+            readonly root_path?: string;
+            /** @description Restrictions on which paths may be shared in guest collections related
+             *     to this mapped collection. On the mapped collection, these paths are
+             *     relative to the root_path property of the mapped collection. On a guest
+             *     collection, they are absolute paths from the storage root.
+             *      */
+            sharing_restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to create new guest
+             *     collections on this mapped collection.
+             *      */
+            sharing_users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to
+             *     create new guest collections on this mapped collection.
+             *      */
+            sharing_users_deny?: string[] | null;
+            /** @description Flag indicating whether the guest collection is subject to automatic
+             *     deletion if auto_delete_timeout is set on its mapped collection. Only
+             *     settable on guest collections. Defaults to false.
+             *      */
+            skip_auto_delete?: boolean;
+            /**
+             * Format: uuid
+             * @description Unique ID of the Storage Gateway which this collection provides
+             *     access to. This value can not change after the collection is
+             *     created.
+             *
+             */
+            storage_gateway_id?: string;
+            /** @description TLSFTP URL for the data on this collection. */
+            readonly tlsftp_url?: string;
+            /**
+             * Format: uuid
+             * @description The ID of the User Credential which is used to access data on this
+             *     collection. This credential must be owned by the collection's
+             *     identity_id.
+             *
+             */
+            user_credential_id?: string;
+            /** @description A message for clients to display to users when interacting with
+             *     this collection. For guest collections, this property is read-only
+             *     and is the same as the value of its related mapped collection. The
+             *     message may be up to 256 characters long.
+             *      */
+            user_message?: string | null;
+            /** @description Link to additional messaging for clients to display to users
+             *     when interacting with this endpoint, linked to an
+             *     HTTP or HTTPS URL. For guest collections, this property is
+             *     read-only and is the same as the value of its related mapped
+             *     collection.
+             *      */
+            user_message_link?: string | null;
+        };
+        /**
+         * CollectionNotFound_1_0_0
+         * @description Error details when a mapped collection no longer exists when accessing a
+         *     guest collection.
+         *
+         */
+        CollectionNotFound_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default collection_not_found#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection_not_found#1.0.0";
+            /**
+             * Format: uuid
+             * @description collection ID
+             */
+            collection_id?: string;
+        };
+        /**
+         * CollectionOwner_1_0_0
+         * @description Schema for processing the collection_owner#1.0.0 data type
+         *
+         */
+        CollectionOwner_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default collection_owner#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "collection_owner#1.0.0";
+            /**
+             * Format: uuid
+             * @description Auth identity ID of the collection owner
+             */
+            identity_id: string;
+        };
+        /**
+         * Connector_1_0_0
+         * @description Connector information document
+         *
+         */
+        Connector_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default connector#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "connector#1.0.0";
+            /**
+             * @description Friendly name of the connector
+             * @example POSIX
+             */
+            display_name: string;
+            /** @description Unique id of this connector type */
+            id: string;
+            /** @description Semantic version of this connector implementation */
+            version?: string;
+        };
+        /**
+         * Connector_1_1_0
+         * @description Connector information document
+         *
+         *         Version 1.1.0 adds information about HA and BAA subscriptions.
+         *
+         */
+        Connector_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default connector#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "connector#1.1.0";
+            /**
+             * @description Friendly name of the connector
+             * @example POSIX
+             */
+            display_name: string;
+            /** @description Unique id of this connector type */
+            id: string;
+            /** @description Subscription for this connector supports a BAA */
+            is_baa?: boolean;
+            /** @description Subscription for this connector supports high assurance */
+            is_ha?: boolean;
+            /** @description Semantic version of this connector implementation */
+            version?: string;
+        };
+        /**
+         * Account
+         * @description User account information for a particular Storage Gateway.
+         */
+        Account: components["schemas"]["Account_1_0_0"];
+        /**
+         * CredentialNotFound_1_0_0
+         * @description Error details when a user has attempted to use a credential when creating a
+         *     collection or logging in, but there are multiple mapped identities and none
+         *     of them have a valid credential.
+         *
+         */
+        CredentialNotFound_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default credential_not_found#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "credential_not_found#1.0.0";
+            /** @description List of available accounts that do not have credentials registered.
+             *      */
+            accounts: components["schemas"]["Account"][];
+        };
+        /**
+         * Endpoint_1_0_0
+         * @description A Globus Connect Server endpoint is a deployment of Globus Connect Server
+         *     version 5. A single endpoint may optionally include multiple data transfer
+         *     nodes. The endpoint provides a link between a Globus Connect Server
+         *     deployment and the Globus Transfer service. The endpoint describes services
+         *     for accessing data via GridFTP and HTTPS and also for configuring and
+         *     managing the policies associated with that access.
+         *
+         */
+        Endpoint_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default endpoint#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "endpoint#1.0.0";
+            /** @description Allow data transfer on this endpoint using the UDT protocol */
+            allow_udt?: boolean;
+            /** @description Email address of the support contact for this endpoint. This is visible to end users so that they may contact your organization for support. */
+            contact_email?: string;
+            /** @description Other non-email contact information for the endpoint, e.g.  phone and mailing address. This is visible to end users for support. */
+            contact_info?: string;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Unicode string, max 1024 characters, no new lines.
+             *      */
+            department?: string;
+            /** @description A description of the endpoint */
+            description?: string;
+            /** @description Friendly name for the endpoint, not unique.  Unicode string, no new
+             *     lines (`\r` or `\n`).  Searchable.
+             *      */
+            display_name: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this endpoint
+             */
+            id?: string;
+            /** @description URL of the GCS Manager API service for this endpoint */
+            readonly gcs_manager_url?: string;
+            /** @description Link to a web page with more information about the endpoint. The
+             *     administrator is responsible for running a website at this URL and
+             *     verifying that it is accepting public connections.
+             *      */
+            info_link?: string;
+            /** @description List of search keywords for the endpoint. Unicode
+             *     string, max 1024 characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_parallelism?: number;
+            /**
+             * @description Control how Globus interacts with this endpoint over the network.
+             *
+             *     Allowed values for **network_use** are:
+             *
+             *     * `normal`
+             *         - The default setting. Uses an average level of concurrency and
+             *           parallelism. The levels depend on the number of physical
+             *           servers in the endpoint.
+             *     * `minimal`
+             *         - Uses a minimal level of concurrency and parallelism.
+             *     * `aggressive`
+             *         - Uses a high level of concurrency and parallelism.
+             *     * `custom`
+             *         - Uses custom values of concurrency and parallelism set by the
+             *           endpoint admin. When setting this level, you must also set
+             *           the **max_concurrency**, **preferred_concurrency**,
+             *           **max_parallelism**, and **preferred_parallelism** properties.
+             *
+             * @default normal
+             * @enum {string}
+             */
+            network_use: "normal" | "minimal" | "aggressive" | "custom";
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_parallelism?: number;
+            /**
+             * @description Flag indicating whether this endpoint is visible to all other
+             *     Globus users. If false, only users which have been granted a role
+             *     on the endpoint or one of its collections, or belong to a domain
+             *     allowed access to any of its storage gateways may view it.
+             *
+             * @default true
+             */
+            public: boolean;
+            /** @description The id of the subscription that is managing this endpoint.  This may be
+             *     the special value `DEFAULT` when using this as input to PATCH or PUT to
+             *     use the caller's default subscription id.
+             *      */
+            subscription_id?: string | null;
+        };
+        /**
+         * Endpoint_1_1_0
+         * @description A Globus Connect Server endpoint is a deployment of Globus Connect Server
+         *     version 5. A single endpoint may optionally include multiple data transfer
+         *     nodes. The endpoint provides a link between a Globus Connect Server
+         *     deployment and the Globus Transfer service. The endpoint describes services
+         *     for accessing data via GridFTP and HTTPS and also for configuring and
+         *     managing the policies associated with that access.
+         *
+         *     Version 1.1.0 of the endpoint includes support for customizing the TCP port
+         *     that the GridFTP listens on.
+         *
+         */
+        Endpoint_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default endpoint#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "endpoint#1.1.0";
+            /** @description Allow data transfer on this endpoint using the UDT protocol */
+            allow_udt?: boolean;
+            /** @description Email address of the support contact for this endpoint. This is visible to end users so that they may contact your organization for support. */
+            contact_email?: string;
+            /** @description Other non-email contact information for the endpoint, e.g.  phone and mailing address. This is visible to end users for support. */
+            contact_info?: string;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Unicode string, max 1024 characters, no new lines.
+             *      */
+            department?: string;
+            /** @description A description of the endpoint */
+            description?: string;
+            /** @description Friendly name for the endpoint, not unique.  Unicode string, no new
+             *     lines (`\r` or `\n`).  Searchable.
+             *      */
+            display_name: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this endpoint
+             */
+            id?: string;
+            /** @description URL of the GCS Manager API service for this endpoint */
+            readonly gcs_manager_url?: string;
+            /** @description TCP port for the Globus control channel to listen on. By default,
+             *     the control channel is passed through 443 with an ALPN header
+             *     containing the value "ftp".
+             *      */
+            gridftp_control_channel_port?: number | null;
+            /** @description Link to a web page with more information about the endpoint. The
+             *     administrator is responsible for running a website at this URL and
+             *     verifying that it is accepting public connections.
+             *      */
+            info_link?: string;
+            /** @description List of search keywords for the endpoint. Unicode
+             *     string, max 1024 characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_parallelism?: number;
+            /**
+             * @description Control how Globus interacts with this endpoint over the network.
+             *
+             *     Allowed values for **network_use** are:
+             *
+             *     * `normal`
+             *         - The default setting. Uses an average level of concurrency and
+             *           parallelism. The levels depend on the number of physical
+             *           servers in the endpoint.
+             *     * `minimal`
+             *         - Uses a minimal level of concurrency and parallelism.
+             *     * `aggressive`
+             *         - Uses a high level of concurrency and parallelism.
+             *     * `custom`
+             *         - Uses custom values of concurrency and parallelism set by the
+             *           endpoint admin. When setting this level, you must also set
+             *           the **max_concurrency**, **preferred_concurrency**,
+             *           **max_parallelism**, and **preferred_parallelism** properties.
+             *
+             * @default normal
+             * @enum {string}
+             */
+            network_use: "normal" | "minimal" | "aggressive" | "custom";
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_parallelism?: number;
+            /**
+             * @description Flag indicating whether this endpoint is visible to all other
+             *     Globus users. If false, only users which have been granted a role
+             *     on the endpoint or one of its collections, or belong to a domain
+             *     allowed access to any of its storage gateways may view it.
+             *
+             * @default true
+             */
+            public: boolean;
+            /** @description The id of the subscription that is managing this endpoint.  This may be
+             *     the special value `DEFAULT` when using this as input to PATCH or PUT to
+             *     use the caller's default subscription id.
+             *      */
+            subscription_id?: string | null;
+        };
+        /**
+         * Endpoint_1_2_0
+         * @description A Globus Connect Server endpoint is a deployment of Globus Connect Server
+         *     version 5. A single endpoint may optionally include multiple data transfer
+         *     nodes. The endpoint provides a link between a Globus Connect Server
+         *     deployment and the Globus Transfer service. The endpoint describes services
+         *     for accessing data via GridFTP and HTTPS and also for configuring and
+         *     managing the policies associated with that access.
+         *
+         *     Version 1.1.0 of the endpoint includes support for customizing the TCP port
+         *     that the GridFTP listens on.
+         *
+         *     Version 1.2.0 of the endpoint includes read-only earliest_last_access
+         *     to put a limit on collections which are missing a last_access value.
+         *
+         */
+        Endpoint_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default endpoint#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "endpoint#1.2.0";
+            /** @description Allow data transfer on this endpoint using the UDT protocol */
+            allow_udt?: boolean;
+            /** @description Email address of the support contact for this endpoint. This is visible to end users so that they may contact your organization for support. */
+            contact_email?: string;
+            /** @description Other non-email contact information for the endpoint, e.g.  phone and mailing address. This is visible to end users for support. */
+            contact_info?: string;
+            /** @description Department within organization that runs the server(s).
+             *     Searchable. Unicode string, max 1024 characters, no new lines.
+             *      */
+            department?: string;
+            /** @description A description of the endpoint */
+            description?: string;
+            /** @description Friendly name for the endpoint, not unique.  Unicode string, no new
+             *     lines (`\r` or `\n`).  Searchable.
+             *      */
+            display_name: string;
+            /**
+             * Format: date
+             * @description Earliest date when this endpoint began tracking last_access for
+             *     collections
+             *
+             */
+            readonly earliest_last_access?: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this endpoint
+             */
+            id?: string;
+            /** @description URL of the GCS Manager API service for this endpoint */
+            readonly gcs_manager_url?: string;
+            /** @description TCP port for the Globus control channel to listen on. By default,
+             *     the control channel is passed through 443 with an ALPN header
+             *     containing the value "ftp".
+             *      */
+            gridftp_control_channel_port?: number | null;
+            /** @description Link to a web page with more information about the endpoint. The
+             *     administrator is responsible for running a website at this URL and
+             *     verifying that it is accepting public connections.
+             *      */
+            info_link?: string;
+            /** @description List of search keywords for the endpoint. Unicode
+             *     string, max 1024 characters total across all strings.
+             *      */
+            keywords?: string[];
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_parallelism?: number;
+            /**
+             * @description Control how Globus interacts with this endpoint over the network.
+             *
+             *     Allowed values for **network_use** are:
+             *
+             *     * `normal`
+             *         - The default setting. Uses an average level of concurrency and
+             *           parallelism. The levels depend on the number of physical
+             *           servers in the endpoint.
+             *     * `minimal`
+             *         - Uses a minimal level of concurrency and parallelism.
+             *     * `aggressive`
+             *         - Uses a high level of concurrency and parallelism.
+             *     * `custom`
+             *         - Uses custom values of concurrency and parallelism set by the
+             *           endpoint admin. When setting this level, you must also set
+             *           the **max_concurrency**, **preferred_concurrency**,
+             *           **max_parallelism**, and **preferred_parallelism** properties.
+             *
+             * @default normal
+             * @enum {string}
+             */
+            network_use: "normal" | "minimal" | "aggressive" | "custom";
+            /** @description Organization that runs the server(s) represented by the endpoint.
+             *     Unicode string, max 1024 characters, no new lines.
+             *      */
+            organization?: string;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_parallelism?: number;
+            /**
+             * @description Flag indicating whether this endpoint is visible to all other
+             *     Globus users. If false, only users which have been granted a role
+             *     on the endpoint or one of its collections, or belong to a domain
+             *     allowed access to any of its storage gateways may view it.
+             *
+             * @default true
+             */
+            public: boolean;
+            /** @description The id of the subscription that is managing this endpoint.  This may be
+             *     the special value `DEFAULT` when using this as input to PATCH or PUT to
+             *     use the caller's default subscription id.
+             *      */
+            subscription_id?: string | null;
+        };
+        /**
+         * EndpointOwner_1_0_0
+         * @description Schema for processing the endpoint_owner#1.0.0 data type
+         *
+         */
+        EndpointOwner_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default endpoint_owner#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "endpoint_owner#1.0.0";
+            /**
+             * Format: uuid
+             * @description Auth identity ID of the endpoint owner
+             */
+            identity_id: string;
+        };
+        /**
+         * EndpointSubscription_1_0_0
+         * @description Endpoint subscription
+         *
+         */
+        EndpointSubscription_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default endpoint_subscription#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "endpoint_subscription#1.0.0";
+            /** @description Either the id of a Globus subscription or the special value
+             *     "DEFAULT" if the caller has only one subscription associated with
+             *     their identity set.
+             *      */
+            subscription_id: string | null;
+        };
+        /**
+         * IdNotInIdentitySet_1_0_0
+         * @description Error details when a user has authenticated but has requested to act as an
+         *     identity not in the current identity set.
+         *
+         */
+        IdNotInIdentitySet_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default id_not_in_identity_set#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "id_not_in_identity_set#1.0.0";
+            /**
+             * Format: uuid
+             * @description Requested identity ID
+             */
+            id?: string;
+        };
+        /**
+         * Info_1_0_0
+         * @description This document contains information about the Globus Connect
+         *     Server, including its software and supported API version
+         *     number.
+         *
+         */
+        Info_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default info#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "info#1.0.0";
+            /** @description Semantic version of the Globus Connect Server API */
+            api_version?: string;
+            /**
+             * Format: uuid
+             * @description Client id that created the endpoint
+             */
+            client_id?: string;
+            /** @description Domain name for the GCS Manager service */
+            domain_name?: string;
+            /**
+             * Format: uuid
+             * @description Transfer endpoint ID managed by this GCS Manager
+             */
+            endpoint_id?: string;
+            /** @description Globus Connect Server software version */
+            manager_version?: string;
+        };
+        /**
+         * InvalidCredential_1_0_0
+         * @description Error details when the caller's identity maps to an account with a user
+         *     credential that is in an invalid state.
+         *
+         */
+        InvalidCredential_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default invalid_credential#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "invalid_credential#1.0.0";
+            /**
+             * Format: uuid
+             * @description The ID of the user credential which needs to be fixed before this
+             *     resource can be accessed.
+             *
+             */
+            user_credential_id: string;
+        };
+        /**
+         * InvalidInputItem
+         * @description Invalid input item details.
+         *
+         */
+        InvalidInputItem: {
+            /** @description Name of the property whose value contains the error, if known. May
+             *     be unset depending on the error.
+             *      */
+            property?: string;
+            /** @description Error message describing the invalid input error */
+            message: string;
+        };
+        /**
+         * InvalidInput_1_0_0
+         * @description Error details when the caller has sent an invalid input document.
+         *
+         */
+        InvalidInput_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default invalid_input#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "invalid_input#1.0.0";
+            /** @description Optional list of input schema violations, such as missing or
+             *     unknown properties, or properties with invalid values.
+             *      */
+            errors?: components["schemas"]["InvalidInputItem"][];
+        };
+        /**
+         * InvalidUser_1_0_0
+         * @description Error details when the caller's identity does not map to valid local
+         *     account.
+         *
+         */
+        InvalidUser_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default invalid_user#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "invalid_user#1.0.0";
+            /** @description List of connector-specific usernames */
+            usernames?: string[];
+        };
+        /**
+         * ExternalIdentityMapping_1_0_0
+         * @description The ExternalIdentityMapping defines the path and arguments of an external
+         *     program to map an identity to a storage-gateway specific user account name.
+         *     The specified command will be called to map Globus Auth identity data to a
+         *     connector-specific list of account names.
+         *
+         */
+        ExternalIdentityMapping_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default external_identity_mapping#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "external_identity_mapping#1.0.0";
+            /** @description The mapping command and its command-line arguments.  In addition to
+             *     these arguments, the following will also be passed to the program.
+             *
+             *     <dl><dt>-c <em>CONNECTOR_ID</em></dt>
+             *     <dd>
+             *     The ID of the connector that the mapping is being
+             *     done in the context of.
+             *     </dd>
+             *     <dt>-s <em>STORAGE_GATEWAY_ID</em></dt>
+             *     <dd>
+             *     The ID of the storage gateway that the mapping is being done in
+             *     the context of.
+             *     </dd>
+             *     <dt>-a</dt>
+             *     <dd>This option is a flag that indicates that the GCS Manager wants to
+             *     receive output containing all mappings for the given identity set.  If
+             *     not present, the program will receive exactly one object in the
+             *     identities array and may only return a single mapping for that
+             *     identity.
+             *     </dd>
+             *     </dl>
+             *      */
+            command?: string[];
+        };
+        /**
+         * MappingExpression
+         * @description The MappingExpression document type contains information about a mapping
+         *     expression, including the input, match, output, and flags used to process
+         *     this expression.
+         *
+         */
+        MappingExpression: {
+            /** @description Flag indicating the match should be executed as a case insensitive
+             *     comparison. If not present, this defaults to false.
+             *      */
+            ignore_case?: boolean;
+            /** @description Flag indicating the match expression should be done as a literal
+             *     match, ignoring any special regular characters. If not present,
+             *     this defaults to false.
+             *      */
+            literal?: boolean;
+            /** @description An expression which is applied to the output performing
+             *     interpolation on source for determining if this mapping applies.
+             *     This requires a full string match on the source.
+             *      */
+            match?: string;
+            /** @description A string representing the result of the mapping if the match
+             *     succeeded. References to the original identity_set data can be
+             *     interpolated as in the *source* property.  References to match
+             *     groups from the *match* property can be interpolated with numbers
+             *     (indices starting with 0) surrounded by curly brackets `{}`.
+             *      */
+            output?: string;
+            /** @description A string comprised of text plus identity set data field names
+             *     surrounded by curly brackets `{}` which are interpolated into the
+             *     text.
+             *      */
+            source?: string;
+        };
+        /**
+         * ExpressionIdentityMapping_1_0_0
+         * @description The ExpressionIdentityMapping defines a set of identity mapping expressions
+         *     to map Globus Auth identity data to a connector-specific list of account
+         *     names.
+         *
+         */
+        ExpressionIdentityMapping_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default expression_identity_mapping#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "expression_identity_mapping#1.0.0";
+            /** @description Array of expression-based identity mapping values */
+            mappings?: components["schemas"]["MappingExpression"][];
+        };
+        /**
+         * LimitExceeded_1_0_0
+         * @description Error details when a user would be authorized, but the endpoint has reached
+         *     a hard resource limit on the type of object being created.
+         *
+         */
+        LimitExceeded_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default limit_exceeded#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "limit_exceeded#1.0.0";
+        };
+        /**
+         * MissingRoleEntrySchema
+         * @description Missing required role details.
+         *
+         */
+        MissingRoleEntrySchema: {
+            /**
+             * Format: uuid
+             * @description The collection which the role must apply to. If omitted, the role
+             *     must apply to an endpoint.
+             *
+             */
+            collection?: string;
+            /** @enum {string} */
+            role: "owner" | "administrator" | "access_manager" | "activity_manager" | "activity_monitor" | "access_monitor";
+        };
+        /**
+         * MissingRequiredRole_1_0_0
+         * @description Error details when a user has authenticated but lacks a role to be able to
+         *     perform the requested operation.
+         *
+         */
+        MissingRequiredRole_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default missing_required_role#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "missing_required_role#1.0.0";
+            /** @description List of roles authorized to perform this operation */
+            roles?: components["schemas"]["MissingRoleEntrySchema"][];
+        };
+        /**
+         * MissingRequiredScopes_1_0_0
+         * @description Error details when a user has authenticated but lacks an OAuth scope to be
+         *     able to perform the requested operation.
+         *
+         */
+        MissingRequiredScopes_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default missing_required_scopes#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "missing_required_scopes#1.0.0";
+            /** @description List of OAuth scope names */
+            required_scopes?: string[];
+        };
+        /**
+         * Node_1_0_0
+         * @description Services for Globus Connect Server endpoints may be deployed on multiple
+         *     different physical resources, referred to as data transfer nodes. Each node
+         *     may have one or more IP addresses, TCP incoming and outgoing port ranges,
+         *     and a *status* value indicating whether it is configured to actively
+         *     respond to requests or is in maintenance mode.
+         *
+         */
+        Node_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default node#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "node#1.0.0";
+            /**
+             * Format: uuid
+             * @description Unique id string this node. This is system generated and may not
+             *     be included in create requests.
+             *
+             */
+            id?: string;
+            /** @description Allowed port range for incoming TCP data connections */
+            incoming_port_range?: number[];
+            /** @description List of IP addresses for this node */
+            ip_addresses: string[];
+            /** @description Port range used as the source for outgoing TCP data connections */
+            outgoing_port_range?: number[];
+            /**
+             * @description Current status of the Node. If a Node is marked *inactive*, it will
+             *     be removed from the DNS entries for this endpoint and will return
+             *     an error on any attempt to use the Manager API or attempt a
+             *     Transfer using this node.
+             *
+             * @enum {string}
+             */
+            status: "active" | "inactive";
+        };
+        /**
+         * Node_1_1_0
+         * @description Services for Globus Connect Server endpoints may be deployed on multiple
+         *     different physical resources, referred to as data transfer nodes. Each node
+         *     may have one or more IP addresses, TCP incoming and outgoing port ranges,
+         *     and a *status* value indicating whether it is configured to actively
+         *     respond to requests or is in maintenance mode.
+         *
+         *     Version 1.1.0 adds support for setting the data interface on a node.
+         *
+         */
+        Node_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default node#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "node#1.1.0";
+            /** @description IP address on which this node listens for data transfers */
+            data_interface?: string | null;
+            /**
+             * Format: uuid
+             * @description Unique id string this node. This is system generated and may not
+             *     be included in create requests.
+             *
+             */
+            id?: string;
+            /** @description Allowed port range for incoming TCP data connections */
+            incoming_port_range?: number[];
+            /** @description List of IP addresses for this node */
+            ip_addresses: string[];
+            /** @description Port range used as the source for outgoing TCP data connections */
+            outgoing_port_range?: number[];
+            /**
+             * @description Current status of the Node. If a Node is marked *inactive*, it will
+             *     be removed from the DNS entries for this endpoint and will return
+             *     an error on any attempt to use the Manager API or attempt a
+             *     Transfer using this node.
+             *
+             * @enum {string}
+             */
+            status: "active" | "inactive";
+        };
+        /**
+         * Node_1_2_0
+         * @description Services for Globus Connect Server endpoints may be deployed on multiple
+         *     different physical resources, referred to as data transfer nodes. Each node
+         *     may have one or more IP addresses, TCP incoming and outgoing port ranges,
+         *     and a *status* value indicating whether it is configured to actively
+         *     respond to requests or is in maintenance mode.
+         *
+         *     Version 1.1.0 adds support for setting the data interface on a node.
+         *
+         *     Version 1.2.0 adds support for setting an IPv6 data interface on a node.
+         *
+         */
+        Node_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default node#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "node#1.2.0";
+            /** @description IP address on which this node listens for data transfers */
+            data_interface?: string | null;
+            /** @description IPv6 address on which this node listens for data transfers */
+            data_interface6?: string | null;
+            /**
+             * Format: uuid
+             * @description Unique id string this node. This is system generated and may not
+             *     be included in create requests.
+             *
+             */
+            id?: string;
+            /** @description Allowed port range for incoming TCP data connections */
+            incoming_port_range?: number[];
+            /** @description List of IP addresses for this node */
+            ip_addresses: string[];
+            /** @description Port range used as the source for outgoing TCP data connections */
+            outgoing_port_range?: number[];
+            /**
+             * @description Current status of the Node. If a Node is marked *inactive*, it will
+             *     be removed from the DNS entries for this endpoint and will return
+             *     an error on any attempt to use the Manager API or attempt a
+             *     Transfer using this node.
+             *
+             * @enum {string}
+             */
+            status: "active" | "inactive";
+        };
+        /**
+         * NotFromAllowedDomain_1_0_0
+         * @description Error details when a user has authenticated but does not
+         *     have an identity from the required domain to perform the
+         *     requested action.
+         *
+         */
+        NotFromAllowedDomain_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default not_from_allowed_domain#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "not_from_allowed_domain#1.0.0";
+            /** @description List of domains allowed by this resource */
+            allowed_domains?: string[];
+        };
+        /**
+         * NotResourceOwner_1_0_0
+         * @description Error details when a user has authenticated but is not the owner of the
+         *     resource being acted upon.
+         *
+         */
+        NotResourceOwner_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default not_resource_owner#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "not_resource_owner#1.0.0";
+            /**
+             * Format: uuid
+             * @description Identity ID of the owner of the resource
+             */
+            id?: string;
+        };
+        /**
+         * OwnerString_1_0_0
+         * @description Owner string document
+         *
+         */
+        OwnerString_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default owner_string#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "owner_string#1.0.0";
+            /**
+             * Format: uuid
+             * @description Globus Auth Identity id
+             */
+            identity_id?: string;
+        };
+        /**
+         * Result_1_0_0
+         * @description This is the result envelope returned from all operations in this API. Each
+         *     operation may add properties to this base document type with additional
+         *     operation-specific data values.
+         *
+         */
+        Result_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default result#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "result#1.0.0";
+            /** @description String response code */
+            code: string;
+            data?: Record<string, unknown>[];
+            detail?: unknown;
+            /**
+             * @description Boolean flag indicating whether or not additional pages of response
+             *     data may be requested by passing the marker to the same operation.
+             *
+             * @default false
+             */
+            has_next_page: boolean;
+            /** @description Numeric HTTP response code */
+            http_response_code: number;
+            /** @description Opaque marker that may be passed to this API call to fetch the next
+             *     page of results if the returned document has `has_next_page` set to
+             *     true.
+             *      */
+            marker?: string | null;
+            /** @description Message describing this result */
+            message?: string;
+        };
+        /**
+         * Result_1_1_0
+         * @description This is the result envelope returned from all operations in this API. Each
+         *     operation may add properties to this base document type with additional
+         *     operation-specific data values.
+         *
+         *     Version 1.1.0 adds optional authorization_parameters to help process
+         *     authorization or authentication errors
+         *
+         */
+        Result_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default result#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "result#1.1.0";
+            authorization_parameters?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description String response code */
+            code: string;
+            data?: Record<string, unknown>[];
+            detail?: unknown;
+            /**
+             * @description Boolean flag indicating whether or not additional pages of response
+             *     data may be requested by passing the marker to the same operation.
+             *
+             * @default false
+             */
+            has_next_page: boolean;
+            /** @description Numeric HTTP response code */
+            http_response_code: number;
+            /** @description Opaque marker that may be passed to this API call to fetch the next
+             *     page of results if the returned document has `has_next_page` set to
+             *     true.
+             *      */
+            marker?: string | null;
+            /** @description Message describing this result */
+            message?: string;
+        };
+        /**
+         * ResourceConflict_1_0_0
+         * @description Error details when the caller has attempted to update an object that
+         *     results in a conflict with some other object.
+         *
+         */
+        ResourceConflict_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default resource_conflict#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "resource_conflict#1.0.0";
+            /** @description List of other resources which conflict with this proposed change.
+             *      */
+            resources?: string[];
+        };
+        /**
+         * Role_1_0_0
+         * @description The "Role" document type represents the assignment of a role on an
+         *     Endpoint or Collection to a Globus identity or group.
+         *
+         */
+        Role_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default role#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "role#1.0.0";
+            /**
+             * Format: uuid
+             * @description Unique id string for this role assignment. This is system generated
+             *     and should not be included in create requests.
+             *
+             */
+            id?: string;
+            /** @description Globus Auth identity or group id URN */
+            principal: string;
+            /**
+             * Format: uuid
+             * @description Collection Id. This value is omitted when creating an endpoint role
+             *     or when creating role definitions when creating "collections.
+             *
+             */
+            collection?: string | null;
+            /**
+             * @description Role assigned to the principal
+             * @enum {string}
+             */
+            role: "owner" | "administrator" | "access_manager" | "activity_manager" | "activity_monitor" | "access_monitor";
+        };
+        /**
+         * IdentityMapping
+         * @description Globus Connect Server provides two ways for you to implement a custom
+         *     Globus identity to account mapping: expression-based and external program
+         *
+         *     With expression-based mapping you can write rules that extract data from
+         *     fields in the Globus identity document to form storage gateway-specific
+         *     usernames. If there is a regular relationship between most of your users'
+         *     Identity information to their account names, this is probably the most
+         *     direct way to accomplish the mapping.
+         *
+         *     With external program mappings you can use any mechanism you like (static
+         *     mapping, ldap, database, etc) to look up account information and return the
+         *     mapped account user name. If you have an account system that has usernames
+         *     without a simple relationship to your users' Globus identities, or that
+         *     requires interfacing with an accounting system, this may be necessary.
+         *
+         */
+        IdentityMapping: components["schemas"]["ExternalIdentityMapping_1_0_0"] | components["schemas"]["ExpressionIdentityMapping_1_0_0"];
+        /**
+         * StorageGateway_1_0_0
+         * @description A storage gateway provides the access policies for the endpoint's
+         *     connected storage systems. It is a named interface by which
+         *     authorized users can create and manage collections on the
+         *     connected storage system. A single storage system may be
+         *     associated with multiple storage gateways, each with its own
+         *     policies.
+         *
+         *     Storage gateway policies describe what type connector the storage
+         *     gateway uses, the paths it allows access to, the login
+         *     requirements are for the storage gateway, and the algorithm to
+         *     map Globus identities to the user namespace of the storage
+         *     gateway (e.g. local accounts).
+         *
+         */
+        StorageGateway_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default storage_gateway#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "storage_gateway#1.0.0";
+            /** @description List of allowed domains. Users creating credentials or collections
+             *     on this storage gateway must have an identity in one of these domains.
+             *      */
+            allowed_domains?: string[];
+            /**
+             * @deprecated
+             * @description Alias for **authentication_timeout_mins**
+             */
+            authentication_assurance_timeout?: number | null;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated to access files or create user credentials on this
+             *     storage gateway.
+             *
+             *     For a high assurance storage gateway, this must be done within the
+             *     current Globus Auth session, otherwise, the caller can perform the
+             *     authentication with any application which uses Globus Auth.
+             *      */
+            authentication_timeout_mins?: number | null;
+            /**
+             * Format: uuid
+             * @description Id of the connector type that this storage gateway interacts with.
+             *
+             */
+            connector_id?: string;
+            /** @description Flag indicating that this storage gateway has been deleted */
+            deleted?: boolean;
+            /** @description Name of the storage gateway */
+            display_name?: string;
+            /** @description Flag indicating if the storage_gateway requires high
+             *     assurance features.
+             *      */
+            high_assurance?: boolean | null;
+            /**
+             * Format: uuid
+             * @description Unique id for this storage gateway
+             */
+            id?: string;
+            /** @description List of identity mappings to apply to user identities to determine
+             *     what connector-specific accounts are available for access.
+             *      */
+            identity_mappings?: components["schemas"]["IdentityMapping"][] | null;
+            /** @description Name of the DSI module to load by the GridFTP server when
+             *     accessing this storage gateway.
+             *      */
+            load_dsi_module?: string | null;
+            /** @description Connector-specific storage policies */
+            policies?: components["schemas"]["S3StoragePolicies_1_0_0"] | components["schemas"]["S3StoragePolicies_1_1_0"] | components["schemas"]["S3StoragePolicies_1_2_0"] | components["schemas"]["AzureBlobStoragePolicies_1_0_0"] | components["schemas"]["AzureBlobStoragePolicies_1_1_0"] | components["schemas"]["BlackPearlStoragePolicies_1_0_0"] | components["schemas"]["BoxStorage_1_0_0"] | components["schemas"]["BoxStorage_1_1_0"] | components["schemas"]["BoxStorage_1_2_0"] | components["schemas"]["CephStoragePolicies_1_0_0"] | components["schemas"]["DropboxStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_1_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_0_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_1_0"] | components["schemas"]["HPSSStoragePolicies_1_0_0"] | components["schemas"]["HPSSStoragePolicies_1_1_0"] | components["schemas"]["IrodsStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_1_0"] | components["schemas"]["PosixStoragePolicies_1_0_0"] | components["schemas"]["PosixStagingStoragePolicies_1_0_0"];
+            /** @description Local POSIX user the GridFTP server should run as when accessing
+             *     this storage gateway.
+             *      */
+            process_user?: string | null;
+            /**
+             * @deprecated
+             * @description Alias for **high_assurance**
+             */
+            require_high_assurance?: boolean | null;
+            /** @description Path restrictions within this storage gateway. Paths are
+             *     interpreted as absolute paths in the file namespace of the
+             *     connector.
+             *      */
+            restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to access this storage
+             *     gateway.
+             *      */
+            users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to this storage
+             *     gateway.
+             *      */
+            users_deny?: string[] | null;
+        };
+        /**
+         * StorageGateway_1_1_0
+         * @description A storage gateway provides the access policies for the endpoint's
+         *     connected storage systems. It is a named interface by which
+         *     authorized users can create and manage collections on the
+         *     connected storage system. A single storage system may be
+         *     associated with multiple storage gateways, each with its own
+         *     policies.
+         *
+         *     Storage gateway policies describe what type connector the storage
+         *     gateway uses, the paths it allows access to, the login
+         *     requirements are for the storage gateway, and the algorithm to
+         *     map Globus identities to the user namespace of the storage
+         *     gateway (e.g. local accounts).
+         *
+         *     Version 1.1.0 includes support for multi-factor authentication requirements
+         *     for high assurance storage gateways.
+         *
+         */
+        StorageGateway_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default storage_gateway#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "storage_gateway#1.1.0";
+            /** @description List of allowed domains. Users creating credentials or collections
+             *     on this storage gateway must have an identity in one of these domains.
+             *      */
+            allowed_domains?: string[];
+            /**
+             * @deprecated
+             * @description Alias for **authentication_timeout_mins**
+             */
+            authentication_assurance_timeout?: number | null;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated to access files or create user credentials on this
+             *     storage gateway.
+             *
+             *     For a high assurance storage gateway, this must be done within the
+             *     current Globus Auth session, otherwise, the caller can perform the
+             *     authentication with any application which uses Globus Auth.
+             *      */
+            authentication_timeout_mins?: number | null;
+            /**
+             * Format: uuid
+             * @description Id of the connector type that this storage gateway interacts with.
+             *
+             */
+            connector_id?: string;
+            /** @description Flag indicating that this storage gateway has been deleted */
+            deleted?: boolean;
+            /** @description Name of the storage gateway */
+            display_name?: string;
+            /** @description Flag indicating if the storage_gateway requires high
+             *     assurance features.
+             *      */
+            high_assurance?: boolean | null;
+            /**
+             * Format: uuid
+             * @description Unique id for this storage gateway
+             */
+            id?: string;
+            /** @description List of identity mappings to apply to user identities to determine
+             *     what connector-specific accounts are available for access.
+             *      */
+            identity_mappings?: components["schemas"]["IdentityMapping"][] | null;
+            /** @description Name of the DSI module to load by the GridFTP server when
+             *     accessing this storage gateway.
+             *      */
+            load_dsi_module?: string | null;
+            /** @description Connector-specific storage policies */
+            policies?: components["schemas"]["S3StoragePolicies_1_0_0"] | components["schemas"]["S3StoragePolicies_1_1_0"] | components["schemas"]["S3StoragePolicies_1_2_0"] | components["schemas"]["AzureBlobStoragePolicies_1_0_0"] | components["schemas"]["AzureBlobStoragePolicies_1_1_0"] | components["schemas"]["BlackPearlStoragePolicies_1_0_0"] | components["schemas"]["BoxStorage_1_0_0"] | components["schemas"]["BoxStorage_1_1_0"] | components["schemas"]["BoxStorage_1_2_0"] | components["schemas"]["CephStoragePolicies_1_0_0"] | components["schemas"]["DropboxStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_1_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_0_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_1_0"] | components["schemas"]["HPSSStoragePolicies_1_0_0"] | components["schemas"]["HPSSStoragePolicies_1_1_0"] | components["schemas"]["IrodsStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_1_0"] | components["schemas"]["PosixStoragePolicies_1_0_0"] | components["schemas"]["PosixStagingStoragePolicies_1_0_0"];
+            /** @description Local POSIX user the GridFTP server should run as when accessing
+             *     this storage gateway.
+             *      */
+            process_user?: string | null;
+            /**
+             * @deprecated
+             * @description Alias for **high_assurance**
+             */
+            require_high_assurance?: boolean | null;
+            /**
+             * @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only usable on high assurance storage gateways.
+             *
+             * @default false
+             */
+            require_mfa: boolean;
+            /** @description Path restrictions within this storage gateway. Paths are
+             *     interpreted as absolute paths in the file namespace of the
+             *     connector.
+             *      */
+            restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to access this storage
+             *     gateway.
+             *      */
+            users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to this storage
+             *     gateway.
+             *      */
+            users_deny?: string[] | null;
+        };
+        /**
+         * StorageGateway_1_2_0
+         * @description A storage gateway provides the access policies for the endpoint's
+         *     connected storage systems. It is a named interface by which
+         *     authorized users can create and manage collections on the
+         *     connected storage system. A single storage system may be
+         *     associated with multiple storage gateways, each with its own
+         *     policies.
+         *
+         *     Storage gateway policies describe what type connector the storage
+         *     gateway uses, the paths it allows access to, the login
+         *     requirements are for the storage gateway, and the algorithm to
+         *     map Globus identities to the user namespace of the storage
+         *     gateway (e.g. local accounts).
+         *
+         *     Version 1.1.0 includes support for multi-factor authentication requirements
+         *     for high assurance storage gateways.
+         *
+         *     Version 1.2.0 includes support for admin managed credentials.
+         *
+         */
+        StorageGateway_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default storage_gateway#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "storage_gateway#1.2.0";
+            /**
+             * @description Flag indicating if the storage_gateway allows endpoint
+             *     administrators to manage user credentials on behalf of other users.
+             *
+             * @default false
+             */
+            admin_managed_credentials: boolean;
+            /** @description List of allowed domains. Users creating credentials or collections
+             *     on this storage gateway must have an identity in one of these domains.
+             *      */
+            allowed_domains?: string[];
+            /**
+             * @deprecated
+             * @description Alias for **authentication_timeout_mins**
+             */
+            authentication_assurance_timeout?: number | null;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated to access files or create user credentials on this
+             *     storage gateway.
+             *
+             *     For a high assurance storage gateway, this must be done within the
+             *     current Globus Auth session, otherwise, the caller can perform the
+             *     authentication with any application which uses Globus Auth.
+             *      */
+            authentication_timeout_mins?: number | null;
+            /**
+             * Format: uuid
+             * @description Id of the connector type that this storage gateway interacts with.
+             *
+             */
+            connector_id?: string;
+            /** @description Flag indicating that this storage gateway has been deleted */
+            deleted?: boolean;
+            /** @description Name of the storage gateway */
+            display_name?: string;
+            /** @description Flag indicating if the storage_gateway requires high
+             *     assurance features.
+             *      */
+            high_assurance?: boolean | null;
+            /**
+             * Format: uuid
+             * @description Unique id for this storage gateway
+             */
+            id?: string;
+            /** @description List of identity mappings to apply to user identities to determine
+             *     what connector-specific accounts are available for access.
+             *      */
+            identity_mappings?: components["schemas"]["IdentityMapping"][] | null;
+            /** @description Name of the DSI module to load by the GridFTP server when
+             *     accessing this storage gateway.
+             *      */
+            load_dsi_module?: string | null;
+            /** @description Connector-specific storage policies */
+            policies?: components["schemas"]["S3StoragePolicies_1_0_0"] | components["schemas"]["S3StoragePolicies_1_1_0"] | components["schemas"]["S3StoragePolicies_1_2_0"] | components["schemas"]["AzureBlobStoragePolicies_1_0_0"] | components["schemas"]["AzureBlobStoragePolicies_1_1_0"] | components["schemas"]["BlackPearlStoragePolicies_1_0_0"] | components["schemas"]["BoxStorage_1_0_0"] | components["schemas"]["BoxStorage_1_1_0"] | components["schemas"]["BoxStorage_1_2_0"] | components["schemas"]["CephStoragePolicies_1_0_0"] | components["schemas"]["DropboxStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_1_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_0_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_1_0"] | components["schemas"]["HPSSStoragePolicies_1_0_0"] | components["schemas"]["HPSSStoragePolicies_1_1_0"] | components["schemas"]["IrodsStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_1_0"] | components["schemas"]["PosixStoragePolicies_1_0_0"] | components["schemas"]["PosixStagingStoragePolicies_1_0_0"];
+            /** @description Local POSIX user the GridFTP server should run as when accessing
+             *     this storage gateway.
+             *      */
+            process_user?: string | null;
+            /**
+             * @deprecated
+             * @description Alias for **high_assurance**
+             */
+            require_high_assurance?: boolean | null;
+            /**
+             * @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only usable on high assurance storage gateways.
+             *
+             * @default false
+             */
+            require_mfa: boolean;
+            /** @description Path restrictions within this storage gateway. Paths are
+             *     interpreted as absolute paths in the file namespace of the
+             *     connector.
+             *      */
+            restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to access this storage
+             *     gateway.
+             *      */
+            users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to this storage
+             *     gateway.
+             *      */
+            users_deny?: string[] | null;
+        };
+        /**
+         * StorageGateway_1_3_0
+         * @description A storage gateway provides the access policies for the endpoint's
+         *     connected storage systems. It is a named interface by which
+         *     authorized users can create and manage collections on the
+         *     connected storage system. A single storage system may be
+         *     associated with multiple storage gateways, each with its own
+         *     policies.
+         *
+         *     Storage gateway policies describe what type connector the storage
+         *     gateway uses, the paths it allows access to, the login
+         *     requirements are for the storage gateway, and the algorithm to
+         *     map Globus identities to the user namespace of the storage
+         *     gateway (e.g. local accounts).
+         *
+         *     Version 1.1.0 includes support for multi-factor authentication requirements
+         *     for high assurance storage gateways.
+         *
+         *     Version 1.2.0 includes support for admin managed credentials.
+         *
+         *     Version 1.3.0 includes support for overriding the endpoint's network use
+         *     parameters on a storage gateway.
+         *
+         */
+        StorageGateway_1_3_0: {
+            /**
+             * @description Type of this document
+             * @default storage_gateway#1.3.0
+             * @enum {string}
+             */
+            DATA_TYPE: "storage_gateway#1.3.0";
+            /**
+             * @description Flag indicating if the storage_gateway allows endpoint
+             *     administrators to manage user credentials on behalf of other users.
+             *
+             * @default false
+             */
+            admin_managed_credentials: boolean;
+            /** @description List of allowed domains. Users creating credentials or collections
+             *     on this storage gateway must have an identity in one of these domains.
+             *      */
+            allowed_domains?: string[];
+            /**
+             * @deprecated
+             * @description Alias for **authentication_timeout_mins**
+             */
+            authentication_assurance_timeout?: number | null;
+            /** @description Timeout (in minutes) during which a user is required to have
+             *     authenticated to access files or create user credentials on this
+             *     storage gateway.
+             *
+             *     For a high assurance storage gateway, this must be done within the
+             *     current Globus Auth session, otherwise, the caller can perform the
+             *     authentication with any application which uses Globus Auth.
+             *      */
+            authentication_timeout_mins?: number | null;
+            /**
+             * Format: uuid
+             * @description Id of the connector type that this storage gateway interacts with.
+             *
+             */
+            connector_id?: string;
+            /** @description Flag indicating that this storage gateway has been deleted */
+            deleted?: boolean;
+            /** @description Name of the storage gateway */
+            display_name?: string;
+            /** @description Flag indicating if the storage_gateway requires high
+             *     assurance features.
+             *      */
+            high_assurance?: boolean | null;
+            /**
+             * Format: uuid
+             * @description Unique id for this storage gateway
+             */
+            id?: string;
+            /** @description List of identity mappings to apply to user identities to determine
+             *     what connector-specific accounts are available for access.
+             *      */
+            identity_mappings?: components["schemas"]["IdentityMapping"][] | null;
+            /** @description Name of the DSI module to load by the GridFTP server when
+             *     accessing this storage gateway.
+             *      */
+            load_dsi_module?: string | null;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            max_parallelism?: number;
+            /**
+             * @description Control how Globus interacts with this endpoint over the network.
+             *
+             *     Allowed values for **network_use** are:
+             *
+             *     * `normal`
+             *         - The default setting. Uses an average level of concurrency and
+             *           parallelism. The levels depend on the number of physical
+             *           servers in the endpoint.
+             *     * `minimal`
+             *         - Uses a minimal level of concurrency and parallelism.
+             *     * `aggressive`
+             *         - Uses a high level of concurrency and parallelism.
+             *     * `custom`
+             *         - Uses custom values of concurrency and parallelism set by the
+             *           endpoint admin. When setting this level, you must also set
+             *           the **max_concurrency**, **preferred_concurrency**,
+             *           **max_parallelism**, and **preferred_parallelism** properties.
+             *
+             * @enum {string|null}
+             */
+            network_use?: "normal" | "minimal" | "aggressive" | "custom" | null;
+            /** @description Connector-specific storage policies */
+            policies?: components["schemas"]["S3StoragePolicies_1_0_0"] | components["schemas"]["S3StoragePolicies_1_1_0"] | components["schemas"]["S3StoragePolicies_1_2_0"] | components["schemas"]["AzureBlobStoragePolicies_1_0_0"] | components["schemas"]["AzureBlobStoragePolicies_1_1_0"] | components["schemas"]["BlackPearlStoragePolicies_1_0_0"] | components["schemas"]["BoxStorage_1_0_0"] | components["schemas"]["BoxStorage_1_1_0"] | components["schemas"]["BoxStorage_1_2_0"] | components["schemas"]["CephStoragePolicies_1_0_0"] | components["schemas"]["DropboxStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_1_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_0_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_1_0"] | components["schemas"]["HPSSStoragePolicies_1_0_0"] | components["schemas"]["HPSSStoragePolicies_1_1_0"] | components["schemas"]["IrodsStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_1_0"] | components["schemas"]["PosixStoragePolicies_1_0_0"] | components["schemas"]["PosixStagingStoragePolicies_1_0_0"];
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_concurrency?: number;
+            /** @description Admin-specified value when the **network_use** property's value is
+             *     `custom`; otherwise the preset value for the specified
+             *     **network_use**.
+             *      */
+            preferred_parallelism?: number;
+            /** @description Local POSIX user the GridFTP server should run as when accessing
+             *     this storage gateway.
+             *      */
+            process_user?: string | null;
+            /**
+             * @deprecated
+             * @description Alias for **high_assurance**
+             */
+            require_high_assurance?: boolean | null;
+            /**
+             * @description Flag indicating if the storage_gateway requires multi-factor
+             *     authentication. Only usable on high assurance storage gateways.
+             *
+             * @default false
+             */
+            require_mfa: boolean;
+            /** @description Path restrictions within this storage gateway. Paths are
+             *     interpreted as absolute paths in the file namespace of the
+             *     connector.
+             *      */
+            restrict_paths?: unknown | components["schemas"]["PathRestrictions"];
+            /** @description List of connector-specific usernames allowed to access this storage
+             *     gateway.
+             *      */
+            users_allow?: string[] | null;
+            /** @description List of connector-specific usernames denied access to this storage
+             *     gateway.
+             *      */
+            users_deny?: string[] | null;
+        };
+        /**
+         * StorageGatewayNotFound_1_0_0
+         * @description Error details when a storage gateway no longer exists when accessing a
+         *     collection.
+         *
+         */
+        StorageGatewayNotFound_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default storage_gateway_not_found#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "storage_gateway_not_found#1.0.0";
+            /**
+             * Format: uuid
+             * @description Storage gateway ID
+             */
+            storage_gateway_id?: string;
+        };
+        /**
+         * SubscriptionRequired_1_0_0
+         * @description Error details when the caller has attempted to access a feature
+         *     not supported by the endpoint's subscription.
+         *
+         */
+        SubscriptionRequired_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default subscription_required#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "subscription_required#1.0.0";
+            /** @description List of subscription add-ons required for this feature */
+            add_ons?: string[];
+            /** @description Level of subscription required for this feature */
+            subscription_level?: string;
+        };
+        /**
+         * UserCredential_1_0_0
+         * @description Credential information for an identity on a particular storage gateway and
+         *     its related collections.
+         *
+         */
+        UserCredential_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default user_credential#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "user_credential#1.0.0";
+            /**
+             * Format: uuid
+             * @description Id of the connector type used by this credential
+             */
+            connector_id?: string;
+            /** @description Flag indicating that this credential has been deleted */
+            deleted?: boolean;
+            /** @description Display name of the credential */
+            display_name?: string | null;
+            /** @description The home directory of this account associated with this credential */
+            readonly home_directory?: string;
+            /**
+             * Format: uuid
+             * @description Unique id for this user credential
+             */
+            id?: string;
+            /**
+             * Format: uuid
+             * @description Globus Auth identity id that this credential is associated with
+             */
+            identity_id?: string;
+            /** @description Flag indicating that this credential is no longer valid */
+            invalid?: boolean;
+            /** @description Connector-specific user credential policies */
+            policies?: components["schemas"]["S3UserCredentialPolicies_1_0_0"] | components["schemas"]["S3UserCredentialPolicies_1_1_0"] | components["schemas"]["S3UserCredentialPolicies_1_2_0"] | components["schemas"]["AzureBlobUserCredentialPolicies_1_0_0"] | components["schemas"]["BlackPearlUserCredentialPolicies_1_0_0"] | components["schemas"]["BoxUserCredential_1_0_0"] | components["schemas"]["BoxUserCredential_1_1_0"] | components["schemas"]["CephUserCredentialPolicies_1_0_0"] | components["schemas"]["DropboxUserCredentialPolicies_1_0_0"] | components["schemas"]["GoogleCloudStorageUserCredentialPolicies_1_0_0"] | components["schemas"]["GoogleDriveUserCredentialPolicies_1_0_0"] | components["schemas"]["HPSSUserCredentialPolicies_1_0_0"] | components["schemas"]["IrodsUserCredentialPolicies_1_0_0"] | components["schemas"]["OneDriveUserCredentialPolicies_1_0_0"] | components["schemas"]["PosixUserCredentialPolicies_1_0_0"] | components["schemas"]["PosixStagingUserCredentialPolicies_1_0_0"];
+            /** @description Flag indicating that this credential has been fully provisioned. If
+             *     this is false and the invalid property is true, then the credential
+             *     was created during login and patching it to add the missing data
+             *     should be presented to the user as initializing the credential.
+             *      */
+            provisioned?: boolean;
+            /**
+             * Format: uuid
+             * @description Storage Gateway this credential is associated with
+             */
+            storage_gateway_id?: string;
+            /** @description Connector-specific username that this credential is associated
+             *     with. If the connector supports identity mapping, this matches the
+             *     result of the mapping applied to identity_id.
+             *      */
+            username?: string;
+        };
+        /**
+         * S3StoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the S3 connector
+         *
+         */
+        S3StoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default s3_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_storage_policies#1.0.0";
+            /** @description List of buckets not owned by the collection owner that will be shown in
+             *     the root of collections created at the base of this storage gateway.
+             *      */
+            s3_buckets?: string[];
+            /**
+             * @description URL of the S3 API endpoint
+             * @example https://s3.amazonaws.com
+             */
+            s3_endpoint?: string;
+            /** @description Flag indicating if a Globus User must register a user credential in
+             *     order to create a guest collection on this storage gateway.
+             *      */
+            s3_user_credential_required?: boolean;
+        };
+        /**
+         * S3StoragePolicies_1_1_0
+         * @description Connector-specific storage gateway policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property
+         *
+         */
+        S3StoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default s3_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_storage_policies#1.1.0";
+            /** @description List of buckets not owned by the collection owner that will be shown in
+             *     the root of collections created at the base of this storage gateway.
+             *      */
+            s3_buckets?: string[];
+            /**
+             * @description URL of the S3 API endpoint
+             * @example https://s3.amazonaws.com
+             */
+            s3_endpoint?: string;
+            /** @description Flag indicating that S3 operations will be charged to the account of
+             *     the registered credentials. Credentials used with a storage gateway
+             *     that has the s3_requester_pays property set to true are invalid unless
+             *     they also have this property set to true as an acknowledgement.
+             *      */
+            s3_requester_pays?: boolean;
+            /** @description Flag indicating if a Globus User must register a user credential in
+             *     order to create a guest collection on this storage gateway.
+             *      */
+            s3_user_credential_required?: boolean;
+        };
+        /**
+         * S3StoragePolicies_1_2_0
+         * @description Connector-specific storage gateway policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property
+         *
+         *     Version 1.2.0 adds support for the s3_allow_multi_keys property
+         *
+         */
+        S3StoragePolicies_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default s3_storage_policies#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_storage_policies#1.2.0";
+            /** @description Allow users of this gateway to add multiple s3 IAM keys to their credentials
+             *      */
+            s3_allow_multi_keys?: boolean;
+            /** @description List of buckets not owned by the collection owner that will be shown in
+             *     the root of collections created at the base of this storage gateway.
+             *      */
+            s3_buckets?: string[];
+            /**
+             * @description URL of the S3 API endpoint
+             * @example https://s3.amazonaws.com
+             */
+            s3_endpoint?: string;
+            /** @description Flag indicating that S3 operations will be charged to the account of
+             *     the registered credentials. Credentials used with a storage gateway
+             *     that has the s3_requester_pays property set to true are invalid unless
+             *     they also have this property set to true as an acknowledgement.
+             *      */
+            s3_requester_pays?: boolean;
+            /** @description Flag indicating if a Globus User must register a user credential in
+             *     order to create a guest collection on this storage gateway.
+             *      */
+            s3_user_credential_required?: boolean;
+        };
+        /**
+         * S3CollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the S3 connector
+         *
+         */
+        S3CollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default s3_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_collection_policies#1.0.0";
+        };
+        /**
+         * S3UserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the S3 connector
+         *
+         */
+        S3UserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default s3_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_user_credential_policies#1.0.0";
+            /** @description Access Key ID to use with the S3 API to access your buckets and
+             *     objects.
+             *      */
+            s3_key_id?: string | null;
+            /** @description Secret key to use with the S3 API to access your buckets and objects.
+             *      */
+            s3_secret_key?: string | null;
+        };
+        /**
+         * S3UserCredentialPolicies_1_1_0
+         * @description Connector-specific user credential policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property.
+         *
+         */
+        S3UserCredentialPolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default s3_user_credential_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_user_credential_policies#1.1.0";
+            /** @description Access Key ID to use with the S3 API to access your buckets and
+             *     objects.
+             *      */
+            s3_key_id?: string | null;
+            /** @description Flag indicating the user acknowledges S3 operations will be charged to
+             *     the account of this credential.  If this flag is true in the storage
+             *     gateway policy, this must also be true or the credential will be invalid.
+             *      */
+            s3_requester_pays?: boolean;
+            /** @description Secret key to use with the S3 API to access your buckets and objects.
+             *      */
+            s3_secret_key?: string | null;
+        };
+        /** S3KeysPrefixPaths_1_0_0 */
+        S3KeysPrefixPaths_1_0_0: {
+            /** @description A list of matching prefix strings. When a S3 object is being accessed its virtual
+             *     path <bucket>/<object> is matched against each string in this list. If the
+             *     virtual path starts with a value in this list then the s3 keys in this object
+             *     will be used.
+             *      */
+            path_prefixes: string[];
+            /** @description Access Key ID to use with the S3 API to access your buckets and
+             *     objects.
+             *      */
+            s3_key_id?: string | null;
+            /** @description Secret key to use with the S3 API to access your buckets and objects.
+             *     If set to null when calling PATCH it indicates that this entry should be
+             *     deleted.
+             *      */
+            s3_secret_key?: string | null;
+        };
+        /**
+         * S3UserCredentialPolicies_1_2_0
+         * @description Connector-specific user credential policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property.
+         *
+         *     Version 1.2.0 adds support for the s3_multi_keys property list.
+         *
+         */
+        S3UserCredentialPolicies_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default s3_user_credential_policies#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "s3_user_credential_policies#1.2.0";
+            /** @description Access Key ID to use with the S3 API to access your buckets and
+             *     objects.
+             *      */
+            s3_key_id?: string | null;
+            /** @description A list of path prefixes and S3 key pairs to use with them.
+             *      */
+            s3_multi_keys?: components["schemas"]["S3KeysPrefixPaths_1_0_0"][] | null;
+            /** @description Flag indicating the user acknowledges S3 operations will be charged to
+             *     the account of this credential.  If this flag is true in the storage
+             *     gateway policy, this must also be true or the credential will be invalid.
+             *      */
+            s3_requester_pays?: boolean;
+            /** @description Secret key to use with the S3 API to access your buckets and objects.
+             *      */
+            s3_secret_key?: string | null;
+        };
+        /**
+         * AzureBlobStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the AzureBlob connector
+         *
+         */
+        AzureBlobStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default azure_blob_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "azure_blob_storage_policies#1.0.0";
+            /** @description Azure Storage account to access with this storage gateway */
+            account: string | null;
+            /** @description Flag indicating the Azure storage account has enabled Azure Data
+             *     Lake Gen2 hierarchical namespace support.
+             *      */
+            adls: boolean | null;
+            /** @description URL of the auth callback that must be registered on the Microsoft
+             *     API console for the application client_id in order to process
+             *     Microsoft credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description The method of authentication to Azure. "user" prompts the user to
+             *     log in to their Microsoft account via an oauth2 flow.
+             *     "service_principal" uses the configured client_id and client_secret
+             *     values to authenticate as an Azure service principal.
+             *      */
+            auth_type: string | null;
+            /** @description Client ID registered with the Azure console to access Azure Blob.
+             *      */
+            client_id: string | null;
+            /** @description Secret created in the Azure console to access Azure Blob with the
+             *     client_id in this policy.
+             *      */
+            secret: string | null;
+            /** @description Tenant id of the Microsoft organization */
+            tenant: string | null;
+            /** @description Flag indicating whether users must register a credential.  If true
+             *     (or if this property is missing), this storage gateway is
+             *     configured for OAuth2 user authentication.  If false,
+             *     authentication is configured by the admin.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * AzureBlobStoragePolicies_1_1_0
+         * @description Connector-specific storage gateway policies for the AzureBlob connector
+         *
+         */
+        AzureBlobStoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default azure_blob_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "azure_blob_storage_policies#1.1.0";
+            /** @description Azure Storage account to access with this storage gateway */
+            account: string | null;
+            /** @description Flag indicating the Azure storage account has enabled Azure Data
+             *     Lake Gen2 hierarchical namespace support.
+             *      */
+            adls: boolean | null;
+            /** @description If true, allow users to access personal or external Microsoft accounts.
+             *     If false (the default), users must use the Microsoft account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be registered on the Microsoft
+             *     API console for the application client_id in order to process
+             *     Microsoft credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description The method of authentication to Azure. "user" prompts the user to
+             *     log in to their Microsoft account via an oauth2 flow.
+             *     "service_principal" uses the configured client_id and client_secret
+             *     values to authenticate as an Azure service principal.
+             *      */
+            auth_type: string | null;
+            /** @description Client ID registered with the Azure console to access Azure Blob.
+             *      */
+            client_id: string | null;
+            /** @description Secret created in the Azure console to access Azure Blob with the
+             *     client_id in this policy.
+             *      */
+            secret: string | null;
+            /** @description Tenant id of the Microsoft organization */
+            tenant: string | null;
+            /** @description Flag indicating whether users must register a credential.  If true
+             *     (or if this property is missing), this storage gateway is
+             *     configured for OAuth2 user authentication.  If false,
+             *     authentication is configured by the admin.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * AzureBlobCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the AzureBlob connector
+         *
+         */
+        AzureBlobCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default azure_blob_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "azure_blob_collection_policies#1.0.0";
+        };
+        /**
+         * AzureBlobUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the AzureBlob connector
+         *
+         */
+        AzureBlobUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default azure_blob_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "azure_blob_user_credential_policies#1.0.0";
+            /** @description OAuth access token */
+            access_token?: string | null;
+            /** @description OAuth email claim */
+            email?: string | null;
+            /** @description OAuth refresh_token token */
+            refresh_token?: string | null;
+            /** @description OAuth scopes associated with this access token */
+            scopes?: string[];
+            /** @description OAuth subject identifier claim */
+            sub?: string | null;
+            /** @description Tenant id */
+            tid?: string;
+            /**
+             * Format: date-time
+             * @description OAuth access token expiration time
+             */
+            token_expiry?: string;
+        };
+        /**
+         * BlackPearlStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Blackpearl connector
+         *
+         */
+        BlackPearlStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default blackpearl_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "blackpearl_storage_policies#1.0.0";
+            /** @description Path to the file which provides mappings from usernames within the
+             *     configured identity domain to the ID and secret associated with the
+             *     user's BlackPearl account
+             *      */
+            bp_access_id_file?: string;
+            /** @description The URL of the S3 endpoint of the BlackPearl appliance
+             *     to use to access collections on this Storage Gateway.
+             *      */
+            s3_endpoint?: string;
+        };
+        /**
+         * BlackPearlCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the BlackPearl connector
+         *
+         */
+        BlackPearlCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default blackpearl_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "blackpearl_collection_policies#1.0.0";
+        };
+        /**
+         * BlackPearlUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Blackpearl connector
+         *
+         */
+        BlackPearlUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default blackpearl_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "blackpearl_user_credential_policies#1.0.0";
+            /** @description BlackPearl access id */
+            readonly access_id?: string;
+            /** @description BlackPearl secret key */
+            readonly secret_key?: string;
+        };
+        /**
+         * BoxAppSettings
+         * @description Values from the Box JWT client configuration that the storage gateway uses
+         *     to identify and authenticate with the Box API.  This is only set when
+         *     configuring the storage gateway for Box enterprise authentication.
+         *
+         */
+        BoxAppSettings: {
+            /** @description Box application keys */
+            appAuth: components["schemas"]["BoxAppAuth"];
+            /** @description Application client ID */
+            clientID: string;
+            /** @description Application client secret */
+            clientSecret: string;
+        };
+        /**
+         * BoxAppAuth
+         * @description Key information used to perform JWT grants for using the Box API
+         *
+         */
+        BoxAppAuth: {
+            /** @description Passphrase to decrypt the private key */
+            passphrase: string;
+            /** @description Private key */
+            privateKey: string;
+            /** @description ID of the public key */
+            publicKeyID: string;
+        };
+        /**
+         * BoxStorage_1_0_0
+         * @description Connector-specific storage gateway policies for the Box connector.
+         *
+         */
+        BoxStorage_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default box_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_storage_policies#1.0.0";
+            /** @description Box Application settings */
+            boxAppSettings: components["schemas"]["BoxAppSettings"];
+            /** @description Identifies which Box Enterprise this storage gateway is authorized
+             *     access to. This is only set when configuring the storage gateway
+             *     for Box enterprise authentication.
+             *      */
+            enterpriseID: string;
+        };
+        /**
+         * BoxStorage_1_1_0
+         * @description Connector-specific storage gateway policies for the Box connector.
+         *
+         */
+        BoxStorage_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default box_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_storage_policies#1.1.0";
+            /** @description URL of the auth callback that must be set on the Box developer
+             *     console for the Box application of client_id.
+             *      */
+            readonly auth_callback?: string;
+            boxAppSettings?: components["schemas"]["BoxAppSettings"];
+            /** @description Client ID of the Box OAuth2 application registered on the Box developer
+             *     console.  This is only set when configuring the storage gateway for
+             *     OAuth2 user authentication.
+             *      */
+            client_id?: string;
+            /** @description Identifies which Box Enterprise this storage gateway is authorized
+             *     access to. This is only set when configuring the storage gateway for
+             *     Box enterprise authentication.
+             *      */
+            enterpriseID?: string;
+            /** @description Secret associated with the client_id set in this policy.  This is only
+             *     set when configuring the storage gateway for OAuth2 user
+             *     authentication.
+             *      */
+            secret?: string;
+            /** @description User API Rate Limit associated with this client ID in operations per
+             *     second per user.
+             *      */
+            user_api_rate_limit?: number;
+            /** @description Flag indicating whether users must register a credential.  If true,
+             *     this storage gateway is configured for OAuth2 user authentication.  If
+             *     false (and for older DATA_TYPE where this property is missing), this
+             *     storage gateway is configured for enterprise authentication.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * BoxStorage_1_2_0
+         * @description Connector-specific storage gateway policies for the Box connector.
+         *
+         */
+        BoxStorage_1_2_0: {
+            /**
+             * @description Type of this document
+             * @default box_storage_policies#1.2.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_storage_policies#1.2.0";
+            /** @description If true, allow users to access personal or external Box accounts.
+             *     If false (the default), users must use the Box account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be set on the Box developer
+             *     console for the Box application of client_id.
+             *      */
+            readonly auth_callback?: string;
+            boxAppSettings?: components["schemas"]["BoxAppSettings"];
+            /** @description Client ID of the Box OAuth2 application registered on the Box developer
+             *     console.  This is only set when configuring the storage gateway for
+             *     OAuth2 user authentication.
+             *      */
+            client_id?: string;
+            /** @description Identifies which Box Enterprise this storage gateway is authorized
+             *     access to. This is only set when configuring the storage gateway for
+             *     Box enterprise authentication.
+             *      */
+            enterpriseID?: string;
+            /** @description Secret associated with the client_id set in this policy.  This is only
+             *     set when configuring the storage gateway for OAuth2 user
+             *     authentication.
+             *      */
+            secret?: string;
+            /** @description User API Rate Limit associated with this client ID in operations per
+             *     second per user.
+             *      */
+            user_api_rate_limit?: number;
+            /** @description Flag indicating whether users must register a credential.  If true,
+             *     this storage gateway is configured for OAuth2 user authentication.  If
+             *     false (and for older DATA_TYPE where this property is missing), this
+             *     storage gateway is configured for enterprise authentication.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * BoxCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Box connector
+         *
+         */
+        BoxCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default box_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_collection_policies#1.0.0";
+        };
+        /**
+         * BoxUserCredential_1_0_0
+         * @description Connector-specific user credential policies for the Box connector
+         *
+         */
+        BoxUserCredential_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default box_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_user_credential_policies#1.0.0";
+        };
+        /**
+         * BoxUserCredential_1_1_0
+         * @description Connector-specific user credential policies for the Box connector
+         *
+         */
+        BoxUserCredential_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default box_user_credential_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "box_user_credential_policies#1.1.0";
+            /** @description OAuth access token */
+            access_token?: string | null;
+            /** @description OAuth email identifier claim */
+            email?: string | null;
+            max_upload?: number;
+            /** @description OAuth refresh token */
+            refresh_token?: string | null;
+            /**
+             * @description OAuth scopes associated with this access token
+             * @example [
+             *       "box_readwrite"
+             *     ]
+             */
+            scopes?: string[];
+            /** @description OAuth subject identifier claim */
+            sub?: string | null;
+            /**
+             * Format: date-time
+             * @description OAuth access token expiration time
+             */
+            token_expiry?: string;
+        };
+        /**
+         * CephStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Ceph connector
+         *
+         */
+        CephStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default ceph_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "ceph_storage_policies#1.0.0";
+            /** @description Administrator key id used to authenticate with the ceph admin service
+             *     to obtain user credentials.
+             *      */
+            ceph_admin_key_id?: string;
+            /** @description Administrator secret key used to authenticate with the ceph admin
+             *     service to obtain user credentials.
+             *      */
+            ceph_admin_secret_key?: string;
+            /** @description List of buckets not owned by the collection owner that will be shown in
+             *     the root of collections created at the base of this Storage Gateway.
+             *      */
+            s3_buckets?: string[];
+            /** @description URL of the Ceph RADOS Gateway S3 API */
+            s3_endpoint?: string;
+        };
+        /**
+         * CephCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Ceph connector
+         *
+         */
+        CephCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default ceph_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "ceph_collection_policies#1.0.0";
+        };
+        /**
+         * CephUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Ceph connector
+         *
+         */
+        CephUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default ceph_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "ceph_user_credential_policies#1.0.0";
+        };
+        /**
+         * DropboxStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Dropbox connector
+         *
+         */
+        DropboxStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default dropbox_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "dropbox_storage_policies#1.0.0";
+            /** @description If true, allow users to access personal or external Dropbox accounts.
+             *     If false (the default), users must use the Dropbox account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be registered on the Dropbox App
+             *     Console for the associated client_id in order to process Dropbox
+             *     credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description Client ID (App key) of the app created in the Dropbox App Console
+             *      */
+            client_id: string | null;
+            /** @description App secret of the app from the Dropbox App Console
+             *     policy.
+             *      */
+            secret: string | null;
+            /** @description User API Rate Limit associated with this client ID in operations per
+             *     second per user.
+             *      */
+            user_api_rate_limit?: number;
+        };
+        /**
+         * DropboxCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Dropbox connector
+         *
+         */
+        DropboxCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default dropbox_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "dropbox_collection_policies#1.0.0";
+        };
+        /**
+         * DropboxUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Dropbox connector
+         *
+         */
+        DropboxUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default dropbox_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "dropbox_user_credential_policies#1.0.0";
+            /** @description OAuth access token */
+            access_token?: string | null;
+            /** @description OAuth email claim */
+            email?: string | null;
+            /** @description OAuth refresh token */
+            refresh_token?: string | null;
+            /**
+             * root_info
+             * @description Root path namespace for Dropbox API requests
+             */
+            root_info?: Record<string, unknown>;
+            /**
+             * @description OAuth scopes associated with this access token
+             * @example [
+             *       "profile",
+             *       "openid",
+             *       "email",
+             *       "account_info.read",
+             *       "files.metadata.read",
+             *       "files.content.write",
+             *       "files.content.read"
+             *     ]
+             */
+            scopes?: string[];
+            /** @description OAuth subject identifier claim */
+            sub?: string | null;
+            /**
+             * Format: date-time
+             * @description OAuth access token expiration time
+             */
+            token_expiry?: string;
+        };
+        /**
+         * GoogleCloudStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_cloud_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_cloud_storage_policies#1.0.0";
+            /** @description URL of the auth callback that must be registered on the Google API
+             *     console for the application client_id in order to process "
+             *     Google credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description The list of Google Cloud Storage buckets which the Storage Gateway is
+             *     allowed to access, as well as the list of buckets that will be shown in
+             *     root level directory listings. If this list is unset, bucket access is
+             *     unrestricted and all non public credential accessible buckets will be
+             *     shown in root level directory listings. The value is a list of bucket
+             *     names.
+             *      */
+            buckets?: string[] | null;
+            /** @description Client ID registered with the Google Application console to access
+             *     Google Cloud Storage.
+             *      */
+            client_id: string | null;
+            /** @description The list of Google Cloud Storage project ids which the Storage Gateway
+             *     is allowed to access. If this list is unset, project access is
+             *     unrestricted. The value is a list of project id strings.
+             *      */
+            projects?: string[] | null;
+            /** @description Secret created to access access Google Cloud Storage with the client_id
+             *     in this policy.
+             *      */
+            secret: string | null;
+            /** @description Service account key to use when authenticating all storage access */
+            service_account_key?: Record<string, unknown> | null;
+            /** @description Flag indicating whether users must register a credential.  If true (or
+             *     if this property is missing), this storage gateway is configured for
+             *     OAuth2 user authentication.  If false, authentication is configured by
+             *     the admin.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * GoogleCloudStoragePolicies_1_1_0
+         * @description Connector-specific storage gateway policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default google_cloud_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_cloud_storage_policies#1.1.0";
+            /** @description If true, allow users to access personal or external Google accounts.
+             *     If false (the default), users must use the Google account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be registered on the Google API
+             *     console for the application client_id in order to process "
+             *     Google credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description The list of Google Cloud Storage buckets which the Storage Gateway is
+             *     allowed to access, as well as the list of buckets that will be shown in
+             *     root level directory listings. If this list is unset, bucket access is
+             *     unrestricted and all non public credential accessible buckets will be
+             *     shown in root level directory listings. The value is a list of bucket
+             *     names.
+             *      */
+            buckets?: string[] | null;
+            /** @description Client ID registered with the Google Application console to access
+             *     Google Cloud Storage.
+             *      */
+            client_id: string | null;
+            /** @description The list of Google Cloud Storage project ids which the Storage Gateway
+             *     is allowed to access. If this list is unset, project access is
+             *     unrestricted. The value is a list of project id strings.
+             *      */
+            projects?: string[] | null;
+            /** @description Secret created to access access Google Cloud Storage with the client_id
+             *     in this policy.
+             *      */
+            secret: string | null;
+            /** @description Service account key to use when authenticating all storage access */
+            service_account_key?: Record<string, unknown> | null;
+            /** @description Flag indicating whether users must register a credential.  If true (or
+             *     if this property is missing), this storage gateway is configured for
+             *     OAuth2 user authentication.  If false, authentication is configured by
+             *     the admin.
+             *      */
+            readonly user_credential_required?: boolean;
+        };
+        /**
+         * GoogleCloudStorageCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStorageCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_cloud_storage_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_cloud_storage_collection_policies#1.0.0";
+            /** @description Google Cloud Platform project ID value that is associated with this
+             *     collection. If set, users must be a member of this project to access
+             *     the collection.  If the storage gateway 'projects' property is set
+             *     to exactly one project, that will be the default value for this property.
+             *      */
+            project?: string;
+        };
+        /**
+         * GoogleCloudStorageProject
+         * @description A Google Cloud Platform project resource
+         *
+         */
+        GoogleCloudStorageProject: {
+            /** @description The name of the project */
+            name?: string;
+            /** @description Google-issued id of a Google Cloud Platform project */
+            projectId?: string;
+        };
+        /**
+         * GoogleCloudStorageUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStorageUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_cloud_storage_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_cloud_storage_user_credential_policies#1.0.0";
+            /** @description Access token to interact with the Google Cloud Storage API */
+            access_token?: string | null;
+            /** @description OpenID Connect email property of this credential */
+            email?: string;
+            /** @description List of Google Cloud Platform projects available for use with this
+             *     credential.
+             *      */
+            projects?: components["schemas"]["GoogleCloudStorageProject"][];
+            /** @description Refresh token to generate new access tokens to use with the Google
+             *     Cloud Storage API
+             *      */
+            refresh_token?: string | null;
+            /** @description List of OAuth2 scopes associated with the tokens in this credential */
+            scopes?: string[];
+            /** @description OpenID Connect subject property of this credential */
+            sub?: string;
+            /**
+             * Format: date-time
+             * @description Time when he access token expires
+             */
+            token_expiry?: string;
+        };
+        /**
+         * GoogleDriveStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Google Drive connector
+         *
+         */
+        GoogleDriveStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_drive_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_drive_storage_policies#1.0.0";
+            /** @description URL of the auth callback that must be registered on the Google API
+             *     console for the application client_id in order to process Google
+             *     credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description Client ID registered with the Google Application console to access
+             *     Google Drive.
+             *      */
+            client_id: string | null;
+            /** @description Secret created to access access Google Drive with the client_id in this
+             *     policy.
+             *      */
+            secret: string | null;
+            /** @description User API Rate quota associated with this client ID */
+            user_api_rate_quota?: number;
+        };
+        /**
+         * GoogleDriveStoragePolicies_1_1_0
+         * @description Connector-specific storage gateway policies for the Google Drive connector
+         *
+         */
+        GoogleDriveStoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default google_drive_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_drive_storage_policies#1.1.0";
+            /** @description If true, allow users to access personal or external Google accounts.
+             *     If false (the default), users must use the Google account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be registered on the Google API
+             *     console for the application client_id in order to process Google
+             *     credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description Client ID registered with the Google Application console to access
+             *     Google Drive.
+             *      */
+            client_id: string | null;
+            /** @description Secret created to access access Google Drive with the client_id in this
+             *     policy.
+             *      */
+            secret: string | null;
+            /** @description User API Rate quota associated with this client ID */
+            user_api_rate_quota?: number;
+        };
+        /**
+         * GoogleDriveCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Google Drive connector
+         *
+         */
+        GoogleDriveCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_drive_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_drive_collection_policies#1.0.0";
+        };
+        /**
+         * GoogleDriveUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Google Drive connector
+         *
+         */
+        GoogleDriveUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default google_drive_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "google_drive_user_credential_policies#1.0.0";
+            /** @description OAuth access token */
+            access_token?: string | null;
+            /** @description OAuth email claim */
+            email?: string | null;
+            /** @description OAuth refresh token */
+            refresh_token?: string | null;
+            /**
+             * @description OAuth scopes associated with this access token
+             * @example [
+             *       "email",
+             *       "profile",
+             *       "https://www.googleapis.com/auth/drive",
+             *       "https://www.googleapis.com/auth/drive.appfolder"
+             *     ]
+             */
+            scopes?: string[];
+            /** @description OAuth subject identifier claim */
+            sub?: string | null;
+            /**
+             * Format: date-time
+             * @description OAuth access token expiration time
+             */
+            token_expiry?: string;
+        };
+        /**
+         * HPSSStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the HPSS connector
+         *
+         */
+        HPSSStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default hpss_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "hpss_storage_policies#1.0.0";
+            /**
+             * @description The type of authentication the connector will perform when logging into HPSS
+             *
+             * @enum {string}
+             */
+            authentication_mech: "krb5" | "unix";
+            /**
+             * @description Authenticator used with authentication mech to perform authentication
+             *     to HPSS. Format is: "<auth_type>:<auth_file>" where <auth_type> is one
+             *     of "auth_keytab" or "auth_keyfile".
+             *
+             * @example auth_keytab:/var/hpss/etc/gridftp.keytab
+             */
+            authenticator: string;
+            /** @description Flag that indicates if checksums should be stored within UDAs so that
+             *     sync-by-checksum transfers can verify the file without staging the file
+             *     from tape.
+             *      */
+            uda_checksum: boolean;
+        };
+        /** HPSSStoragePolicies_1_1_0 */
+        HPSSStoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default hpss_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "hpss_storage_policies#1.1.0";
+            /**
+             * @description The type of authentication the connector will perform when logging into HPSS
+             *
+             * @enum {string}
+             */
+            authentication_mech: "krb5" | "unix";
+            /**
+             * @description Authenticator used with authentication mech to perform authentication
+             *     to HPSS. Format is: "<auth_type>:<auth_file>" where <auth_type> is one
+             *     of "auth_keytab" or "auth_keyfile".
+             *
+             * @example auth_keytab:/var/hpss/etc/gridftp.keytab
+             */
+            authenticator: string;
+            /** @description Name of the HPSS user in the keytab file that the GridFTP server will use
+             *     to authenticate to HPSS. This user must have the ability to switch to another
+             *     HPSS user. Defaults to 'hpssftp' which is also handled special by HPSS with
+             *     regards to the gate keeper.
+             *      */
+            login_name?: string;
+            /** @description Flag that indicates if checksums should be stored within UDAs so that
+             *     sync-by-checksum transfers can verify the file without staging the file
+             *     from tape.
+             *      */
+            uda_checksum: boolean;
+        };
+        /**
+         * HPSSCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the HPSS connector
+         *
+         */
+        HPSSCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default hpss_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "hpss_collection_policies#1.0.0";
+        };
+        /**
+         * HPSSUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the HPSS connector
+         *
+         */
+        HPSSUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default hpss_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "hpss_user_credential_policies#1.0.0";
+        };
+        /**
+         * IrodsEnvironment
+         * @description Variables to set in the iRODS client environment.
+         *
+         */
+        IrodsEnvironment: {
+            /** @description Environment variable name */
+            name: string;
+            /** @description Environment variable value */
+            value: string;
+        };
+        /**
+         * IrodsStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the Irods connector
+         *
+         */
+        IrodsStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default irods_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "irods_storage_policies#1.0.0";
+            /** @description Variables to set in the iRODS client environment */
+            environment?: components["schemas"]["IrodsEnvironment"][];
+            /**
+             * @description Path to the irods authentication file
+             * @example /var/irods/.irodsA
+             */
+            irods_authentication_file?: string;
+            /**
+             * @description Path to the irods environment file
+             * @example /var/irods/irods_environment.json
+             */
+            irods_environment_file: string;
+        };
+        /**
+         * IrodsCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the Irods connector
+         *
+         */
+        IrodsCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default irods_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "irods_collection_policies#1.0.0";
+        };
+        /**
+         * IrodsUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the Irods connector
+         *
+         */
+        IrodsUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default irods_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "irods_user_credential_policies#1.0.0";
+        };
+        /**
+         * OneDriveStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the OneDrive connector
+         *
+         */
+        OneDriveStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default onedrive_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "onedrive_storage_policies#1.0.0";
+            /** @description URL of the auth callback that must be registered on the Microsoft
+             *     API console for the application client_id in order to process
+             *     Microsoft credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description Client ID registered with the Azure console to access OneDrive */
+            client_id: string | null;
+            /** @description Secret created in the Azure console to access OneDrive with the
+             *     client_id in this policy.
+             *      */
+            secret: string | null;
+            /** @description Tenant ID of the Microsoft organization. Required when Supported
+             *     Account Types of the Azure application is set to Single tenant.
+             *      */
+            tenant?: string | null;
+            /** @description User API Rate Limit associated with this client ID in operations per
+             *     second per user.
+             *      */
+            user_api_rate_limit?: number;
+        };
+        /**
+         * OneDriveStoragePolicies_1_1_0
+         * @description Connector-specific storage gateway policies for the OneDrive connector
+         *
+         */
+        OneDriveStoragePolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default onedrive_storage_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "onedrive_storage_policies#1.1.0";
+            /** @description If true, allow users to access personal or external Microsoft accounts.
+             *     If false (the default), users must use the Microsoft account which
+             *     matches the username their Globus credential maps to.
+             *      */
+            allow_any_account?: boolean;
+            /** @description URL of the auth callback that must be registered on the Microsoft
+             *     API console for the application client_id in order to process
+             *     Microsoft credentials.
+             *      */
+            readonly auth_callback?: string;
+            /** @description Client ID registered with the Azure console to access OneDrive */
+            client_id: string | null;
+            /** @description Secret created in the Azure console to access OneDrive with the
+             *     client_id in this policy.
+             *      */
+            secret: string | null;
+            /** @description Tenant ID of the Microsoft organization. Required when Supported
+             *     Account Types of the Azure application is set to Single tenant.
+             *      */
+            tenant?: string | null;
+            /** @description User API Rate Limit associated with this client ID in operations per
+             *     second per user.
+             *      */
+            user_api_rate_limit?: number;
+        };
+        /**
+         * OneDriveCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the OneDrive connector
+         *
+         */
+        OneDriveCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default onedrive_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "onedrive_collection_policies#1.0.0";
+        };
+        /**
+         * OneDriveUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the OneDrive connector
+         *
+         */
+        OneDriveUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default onedrive_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "onedrive_user_credential_policies#1.0.0";
+            /** @description OAuth access token */
+            access_token?: string | null;
+            /** @description OAuth email claim */
+            email?: string | null;
+            /** @description OAuth refresh token */
+            refresh_token?: string | null;
+            /**
+             * @description OAuth scopes associated with the access token
+             * @example [
+             *       "openid",
+             *       "email",
+             *       "profile",
+             *       "offline_access",
+             *       "files.readwrite.all"
+             *     ]
+             */
+            scopes?: string[];
+            /** @description OAuth subject identifier claim */
+            sub?: string | null;
+            tid?: string;
+            /**
+             * Format: date-time
+             * @description OAuth access token expiration time
+             */
+            token_expiry?: string;
+        };
+        /**
+         * PosixStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the POSIX connector.
+         *
+         */
+        PosixStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_storage_policies#1.0.0";
+            /** @description List of POSIX group names allowed to access this storage gateway
+             *      */
+            groups_allow?: string[] | null;
+            /** @description List of POSIX group names denied access this storage gateway
+             *      */
+            groups_deny?: string[] | null;
+        };
+        /**
+         * PosixCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the POSIX connector
+         *
+         */
+        PosixCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_collection_policies#1.0.0";
+        };
+        /**
+         * PosixCollectionPolicies_1_1_0
+         * @description Connector-specific collection policies for the POSIX connector
+         *
+         *
+         *     Version 1.1.0 of the posix_collection_policies document adds the
+         *     **sharing_groups_allow**, and **sharing_groups_deny** properties.
+         *
+         */
+        PosixCollectionPolicies_1_1_0: {
+            /**
+             * @description Type of this document
+             * @default posix_collection_policies#1.1.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_collection_policies#1.1.0";
+            /** @description List of POSIX group names allowed to create shares on this collection
+             *      */
+            sharing_groups_allow?: string[] | null;
+            /** @description List of POSIX group names denied access to create shares on this
+             *     collection.
+             *      */
+            sharing_groups_deny?: string[] | null;
+        };
+        /**
+         * PosixUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the POSIX connector
+         *
+         */
+        PosixUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_user_credential_policies#1.0.0";
+        };
+        /**
+         * PosixStagingEnvironment
+         * @description Variables to set in the environment when executing
+         *     the stage_app.
+         *
+         */
+        PosixStagingEnvironment: {
+            /** @description Environment variable name */
+            name: string;
+            /** @description Environment variable value */
+            value: string;
+        };
+        /**
+         * PosixStagingStoragePolicies_1_0_0
+         * @description Connector-specific storage gateway policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingStoragePolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_staging_storage_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_staging_storage_policies#1.0.0";
+            /** @description Variables to set in the environment when executing the stage_app */
+            environment?: components["schemas"]["PosixStagingEnvironment"][];
+            /** @description List of POSIX group names allowed to access this storage gateway
+             *      */
+            groups_allow?: string[] | null;
+            /** @description List of POSIX group names denied access this storage gateway
+             *      */
+            groups_deny?: string[] | null;
+            /** @description Path to the stage app */
+            stage_app: string;
+        };
+        /**
+         * PosixStagingCollectionPolicies_1_0_0
+         * @description Connector-specific collection policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingCollectionPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_staging_collection_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_staging_collection_policies#1.0.0";
+            /** @description List of POSIX group names allowed to create shares on this collection
+             *      */
+            sharing_groups_allow?: string[] | null;
+            /** @description List of POSIX group names denied access to create shares on this
+             *     collection.
+             *      */
+            sharing_groups_deny?: string[] | null;
+        };
+        /**
+         * PosixStagingUserCredentialPolicies_1_0_0
+         * @description Connector-specific user credential policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingUserCredentialPolicies_1_0_0: {
+            /**
+             * @description Type of this document
+             * @default posix_staging_user_credential_policies#1.0.0
+             * @enum {string}
+             */
+            DATA_TYPE: "posix_staging_user_credential_policies#1.0.0";
+        };
+        /**
+         * Node
+         * @description Services for Globus Connect Server endpoints may be deployed on multiple
+         *     different physical resources, referred to as data transfer nodes. Each node
+         *     may have one or more IP addresses, TCP incoming and outgoing port ranges,
+         *     and a *status* value indicating whether it is configured to actively
+         *     respond to requests or is in maintenance mode.
+         *
+         *     Version 1.1.0 adds support for setting the data interface on a node.
+         *
+         *     Version 1.2.0 adds support for setting an IPv6 data interface on a node.
+         *
+         */
+        Node: components["schemas"]["Node_1_0_0"] | components["schemas"]["Node_1_1_0"] | components["schemas"]["Node_1_2_0"];
+        /**
+         * Batch
+         * @description The Batch data type is used to specify multiple objects to operate
+         *     on via a single REST API call.
+         *
+         */
+        Batch: components["schemas"]["Batch_1_0_0"];
+        /**
+         * AuthenticationTimeout
+         * @description Error details when a user must reauthenticate an identity
+         *     in order to perform this operation.
+         *
+         *     Version 1.1.0 adds the require_mfa property.
+         *
+         */
+        AuthenticationTimeout: components["schemas"]["AuthenticationTimeout_1_0_0"] | components["schemas"]["AuthenticationTimeout_1_1_0"];
+        /**
+         * CheckResult
+         * @description Consistency check information
+         */
+        CheckResult: components["schemas"]["CheckResult_1_0_0"];
+        /**
+         * SharingPolicy
+         * @description Sharing policies for a mapped collection.
+         *
+         *     This document type allows endpoint and collection administrators to
+         *     optionally constrain sharing path policies for particular users. The
+         *     **sharing_restrict_paths** property has a similar meaning to that of the
+         *     **sharing_restrict_paths** in the collection document; however, it is in
+         *     effect only for specific users.
+         *
+         *     If the **users** property is null, then the restriction applies to all
+         *     users. If it is non-null, then this restriction applies only to accounts
+         *     which have been mapped to the enumerated storage gateway user accounts.
+         *
+         *     Multiple sharing policies can be defined for a mapped collection.  When a
+         *     guest collection is created or accessed, only the policies relevant to the
+         *     user which created the account are enforced.
+         *
+         */
+        SharingPolicy: components["schemas"]["SharingPolicy_1_0_0"];
+        /**
+         * Collection
+         * @description A collection consists of metadata about the collection, a DNS
+         *     domain for accessing data on the collection, and configuration on
+         *     the Data Transfer Nodes to access the collection data. Globus
+         *     Connect Server version 5 supports two types of collections:
+         *     **mapped** and **guest**.
+         *
+         *     Version 1.1.0 adds support for enabling or disabling https access for
+         *     individual collections, as well as the ability for collection
+         *     administrators to add an optional message and web link to be shown on
+         *     the Globus Web App when users visit the collection.
+         *
+         *     Version 1.2.0 adds the ability to enable or disable sharing by specific
+         *     users.
+         *
+         *     Version 1.3.0 add support for custom DNS domains on collections.
+         *
+         *     Version 1.4.0 allows optional multi-factor authentication requirements to
+         *     high assurance collections and the ability to require checksums when
+         *     transferring data on this collection.
+         *
+         *     Version 1.5.0 allows administrators to disable permissions that would allow
+         *     anonymous users to have write access to an endpoint.
+         *
+         *     Version 1.6.0 allows administrators of mapped collections to associate
+         *     policies that users accessing guest collections must meet beyond the
+         *     guest collection permissions.
+         *
+         *     Version 1.7.0 increases the maximum allowed length of the user_message
+         *     property.
+         *
+         *     Version 1.8.0 adds the delete_protected property. While it is set to true
+         *     on a mapped collection, the collection may not be deleted. As of GCS 5.4.69,
+         *     this is true by default.
+         *
+         *     Version 1.9.0 adds the read-only last_access and created_at properties.
+         *
+         *     Version 1.10.0 adds the acl_expiration_mins property to HA mapped collections.
+         *
+         *     Version 1.11.0 adds the acl_expiration_mins property to HA guest collection.
+         *
+         *     Version 1.12.0 adds the restrict_transfers_to_high_assurance property to HA
+         *     collections.
+         *
+         *     Version 1.13.0 adds the auto_delete_timeout property to mapped collections
+         *     and the skip_auto_delete property to guest collections.
+         *
+         */
+        Collection: components["schemas"]["Collection_1_0_0"] | components["schemas"]["Collection_1_1_0"] | components["schemas"]["Collection_1_2_0"] | components["schemas"]["Collection_1_3_0"] | components["schemas"]["Collection_1_4_0"] | components["schemas"]["Collection_1_5_0"] | components["schemas"]["Collection_1_6_0"] | components["schemas"]["Collection_1_7_0"] | components["schemas"]["Collection_1_8_0"] | components["schemas"]["Collection_1_9_0"] | components["schemas"]["Collection_1_10_0"] | components["schemas"]["Collection_1_11_0"] | components["schemas"]["Collection_1_12_0"] | components["schemas"]["Collection_1_13_0"];
+        /**
+         * CollectionNotFound
+         * @description Error details when a mapped collection no longer exists when accessing a
+         *     guest collection.
+         *
+         */
+        CollectionNotFound: components["schemas"]["CollectionNotFound_1_0_0"];
+        /**
+         * CollectionOwner
+         * @description Schema for processing the collection_owner#1.0.0 data type
+         *
+         */
+        CollectionOwner: components["schemas"]["CollectionOwner_1_0_0"];
+        /**
+         * Connector
+         * @description Connector information document
+         *
+         *         Version 1.1.0 adds information about HA and BAA subscriptions.
+         *
+         */
+        Connector: components["schemas"]["Connector_1_0_0"] | components["schemas"]["Connector_1_1_0"];
+        /**
+         * CredentialNotFound
+         * @description Error details when a user has attempted to use a credential when creating a
+         *     collection or logging in, but there are multiple mapped identities and none
+         *     of them have a valid credential.
+         *
+         */
+        CredentialNotFound: components["schemas"]["CredentialNotFound_1_0_0"];
+        /**
+         * Endpoint
+         * @description A Globus Connect Server endpoint is a deployment of Globus Connect Server
+         *     version 5. A single endpoint may optionally include multiple data transfer
+         *     nodes. The endpoint provides a link between a Globus Connect Server
+         *     deployment and the Globus Transfer service. The endpoint describes services
+         *     for accessing data via GridFTP and HTTPS and also for configuring and
+         *     managing the policies associated with that access.
+         *
+         *     Version 1.1.0 of the endpoint includes support for customizing the TCP port
+         *     that the GridFTP listens on.
+         *
+         *     Version 1.2.0 of the endpoint includes read-only earliest_last_access
+         *     to put a limit on collections which are missing a last_access value.
+         *
+         */
+        Endpoint: components["schemas"]["Endpoint_1_0_0"] | components["schemas"]["Endpoint_1_1_0"] | components["schemas"]["Endpoint_1_2_0"];
+        /**
+         * EndpointOwner
+         * @description Schema for processing the endpoint_owner#1.0.0 data type
+         *
+         */
+        EndpointOwner: components["schemas"]["EndpointOwner_1_0_0"];
+        /**
+         * EndpointSubscription
+         * @description Endpoint subscription
+         *
+         */
+        EndpointSubscription: components["schemas"]["EndpointSubscription_1_0_0"];
+        /**
+         * IdNotInIdentitySet
+         * @description Error details when a user has authenticated but has requested to act as an
+         *     identity not in the current identity set.
+         *
+         */
+        IdNotInIdentitySet: components["schemas"]["IdNotInIdentitySet_1_0_0"];
+        /**
+         * Info
+         * @description This document contains information about the Globus Connect
+         *     Server, including its software and supported API version
+         *     number.
+         *
+         */
+        Info: components["schemas"]["Info_1_0_0"];
+        /**
+         * InvalidCredential
+         * @description Error details when the caller's identity maps to an account with a user
+         *     credential that is in an invalid state.
+         *
+         */
+        InvalidCredential: components["schemas"]["InvalidCredential_1_0_0"];
+        /**
+         * InvalidInput
+         * @description Error details when the caller has sent an invalid input document.
+         *
+         */
+        InvalidInput: components["schemas"]["InvalidInput_1_0_0"];
+        /**
+         * InvalidUser
+         * @description Error details when the caller's identity does not map to valid local
+         *     account.
+         *
+         */
+        InvalidUser: components["schemas"]["InvalidUser_1_0_0"];
+        /**
+         * LimitExceeded
+         * @description Error details when a user would be authorized, but the endpoint has reached
+         *     a hard resource limit on the type of object being created.
+         *
+         */
+        LimitExceeded: components["schemas"]["LimitExceeded_1_0_0"];
+        /**
+         * MissingRequiredRole
+         * @description Error details when a user has authenticated but lacks a role to be able to
+         *     perform the requested operation.
+         *
+         */
+        MissingRequiredRole: components["schemas"]["MissingRequiredRole_1_0_0"];
+        /**
+         * MissingRequiredScopes
+         * @description Error details when a user has authenticated but lacks an OAuth scope to be
+         *     able to perform the requested operation.
+         *
+         */
+        MissingRequiredScopes: components["schemas"]["MissingRequiredScopes_1_0_0"];
+        /**
+         * NotFromAllowedDomain
+         * @description Error details when a user has authenticated but does not
+         *     have an identity from the required domain to perform the
+         *     requested action.
+         *
+         */
+        NotFromAllowedDomain: components["schemas"]["NotFromAllowedDomain_1_0_0"];
+        /**
+         * NotResourceOwner
+         * @description Error details when a user has authenticated but is not the owner of the
+         *     resource being acted upon.
+         *
+         */
+        NotResourceOwner: components["schemas"]["NotResourceOwner_1_0_0"];
+        /**
+         * OwnerString
+         * @description Owner string document
+         *
+         */
+        OwnerString: components["schemas"]["OwnerString_1_0_0"];
+        /**
+         * Result
+         * @description This is the result envelope returned from all operations in this API. Each
+         *     operation may add properties to this base document type with additional
+         *     operation-specific data values.
+         *
+         *     Version 1.1.0 adds optional authorization_parameters to help process
+         *     authorization or authentication errors
+         *
+         */
+        Result: components["schemas"]["Result_1_0_0"] | components["schemas"]["Result_1_1_0"];
+        /**
+         * ResourceConflict
+         * @description Error details when the caller has attempted to update an object that
+         *     results in a conflict with some other object.
+         *
+         */
+        ResourceConflict: components["schemas"]["ResourceConflict_1_0_0"];
+        /**
+         * Role
+         * @description The "Role" document type represents the assignment of a role on an
+         *     Endpoint or Collection to a Globus identity or group.
+         *
+         */
+        Role: components["schemas"]["Role_1_0_0"];
+        /**
+         * StorageGateway
+         * @description A storage gateway provides the access policies for the endpoint's
+         *     connected storage systems. It is a named interface by which
+         *     authorized users can create and manage collections on the
+         *     connected storage system. A single storage system may be
+         *     associated with multiple storage gateways, each with its own
+         *     policies.
+         *
+         *     Storage gateway policies describe what type connector the storage
+         *     gateway uses, the paths it allows access to, the login
+         *     requirements are for the storage gateway, and the algorithm to
+         *     map Globus identities to the user namespace of the storage
+         *     gateway (e.g. local accounts).
+         *
+         *     Version 1.1.0 includes support for multi-factor authentication requirements
+         *     for high assurance storage gateways.
+         *
+         *     Version 1.2.0 includes support for admin managed credentials.
+         *
+         *     Version 1.3.0 includes support for overriding the endpoint's network use
+         *     parameters on a storage gateway.
+         *
+         */
+        StorageGateway: components["schemas"]["StorageGateway_1_0_0"] | components["schemas"]["StorageGateway_1_1_0"] | components["schemas"]["StorageGateway_1_2_0"] | components["schemas"]["StorageGateway_1_3_0"];
+        /**
+         * StorageGatewayNotFound
+         * @description Error details when a storage gateway no longer exists when accessing a
+         *     collection.
+         *
+         */
+        StorageGatewayNotFound: components["schemas"]["StorageGatewayNotFound_1_0_0"];
+        /**
+         * SubscriptionRequired
+         * @description Error details when the caller has attempted to access a feature
+         *     not supported by the endpoint's subscription.
+         *
+         */
+        SubscriptionRequired: components["schemas"]["SubscriptionRequired_1_0_0"];
+        /**
+         * UserCredential
+         * @description Credential information for an identity on a particular storage gateway and
+         *     its related collections.
+         *
+         */
+        UserCredential: components["schemas"]["UserCredential_1_0_0"];
+        /**
+         * S3StoragePolicies
+         * @description Connector-specific storage gateway policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property
+         *
+         *     Version 1.2.0 adds support for the s3_allow_multi_keys property
+         *
+         */
+        S3StoragePolicies: components["schemas"]["S3StoragePolicies_1_0_0"] | components["schemas"]["S3StoragePolicies_1_1_0"] | components["schemas"]["S3StoragePolicies_1_2_0"];
+        /**
+         * S3CollectionPolicies
+         * @description Connector-specific collection policies for the S3 connector
+         *
+         */
+        S3CollectionPolicies: components["schemas"]["S3CollectionPolicies_1_0_0"];
+        /**
+         * S3UserCredentialPolicies
+         * @description Connector-specific user credential policies for the S3 connector
+         *
+         *     Version 1.1.0 adds support for the s3_requester_pays property.
+         *
+         *     Version 1.2.0 adds support for the s3_multi_keys property list.
+         *
+         */
+        S3UserCredentialPolicies: components["schemas"]["S3UserCredentialPolicies_1_0_0"] | components["schemas"]["S3UserCredentialPolicies_1_1_0"] | components["schemas"]["S3UserCredentialPolicies_1_2_0"];
+        /**
+         * ActiveScaleStoragePolicies
+         * @description Connector-specific storage gateway policies for the ActiveScale connector.
+         *     These are identical to s3 connector's storage gateway policies.
+         *
+         */
+        ActiveScaleStoragePolicies: components["schemas"]["S3StoragePolicies_1_0_0"];
+        /**
+         * ActiveScaleCollectionPolicies
+         * @description Connector-specific storage gateway policies for the ActiveScale connector.
+         *     These are identical to s3 connector's storage gateway policies.
+         *
+         */
+        ActiveScaleCollectionPolicies: components["schemas"]["S3CollectionPolicies"];
+        /**
+         * ActiveScaleUserCredentialPolicies
+         * @description Connector-specific storage gateway policies for the ActiveScale connector.
+         *     These are identical to s3 connector's storage gateway policies.
+         *
+         */
+        ActiveScaleUserCredentialPolicies: components["schemas"]["S3UserCredentialPolicies_1_0_0"];
+        /**
+         * AzureBlobStoragePolicies
+         * @description Connector-specific storage gateway policies for the AzureBlob connector
+         *
+         */
+        AzureBlobStoragePolicies: components["schemas"]["AzureBlobStoragePolicies_1_0_0"] | components["schemas"]["AzureBlobStoragePolicies_1_1_0"];
+        /**
+         * AzureBlobCollectionPolicies
+         * @description Connector-specific collection policies for the AzureBlob connector
+         *
+         */
+        AzureBlobCollectionPolicies: components["schemas"]["AzureBlobCollectionPolicies_1_0_0"];
+        /**
+         * AzureBlobUserCredentialPolicies
+         * @description Connector-specific user credential policies for the AzureBlob connector
+         *
+         */
+        AzureBlobUserCredentialPolicies: components["schemas"]["AzureBlobUserCredentialPolicies_1_0_0"];
+        /**
+         * BlackPearlStoragePolicies
+         * @description Connector-specific storage gateway policies for the Blackpearl connector
+         *
+         */
+        BlackPearlStoragePolicies: components["schemas"]["BlackPearlStoragePolicies_1_0_0"];
+        /**
+         * BlackPearlCollectionPolicies
+         * @description Connector-specific collection policies for the BlackPearl connector
+         *
+         */
+        BlackPearlCollectionPolicies: components["schemas"]["BlackPearlCollectionPolicies_1_0_0"];
+        /**
+         * BlackPearlUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Blackpearl connector
+         *
+         */
+        BlackPearlUserCredentialPolicies: components["schemas"]["BlackPearlUserCredentialPolicies_1_0_0"];
+        /**
+         * BoxStoragePolicies
+         * @description Connector-specific storage gateway policies for the Box connector.
+         *
+         */
+        BoxStoragePolicies: components["schemas"]["BoxStorage_1_0_0"] | components["schemas"]["BoxStorage_1_1_0"] | components["schemas"]["BoxStorage_1_2_0"];
+        /**
+         * BoxCollectionPolicies
+         * @description Connector-specific collection policies for the Box connector
+         *
+         */
+        BoxCollectionPolicies: components["schemas"]["BoxCollectionPolicies_1_0_0"];
+        /**
+         * BoxUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Box connector
+         *
+         */
+        BoxUserCredentialPolicies: components["schemas"]["BoxUserCredential_1_0_0"] | components["schemas"]["BoxUserCredential_1_1_0"];
+        /**
+         * CephStoragePolicies
+         * @description Connector-specific storage gateway policies for the Ceph connector
+         *
+         */
+        CephStoragePolicies: components["schemas"]["CephStoragePolicies_1_0_0"];
+        /**
+         * CephCollectionPolicies
+         * @description Connector-specific collection policies for the Ceph connector
+         *
+         */
+        CephCollectionPolicies: components["schemas"]["CephCollectionPolicies_1_0_0"];
+        /**
+         * CephUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Ceph connector
+         *
+         */
+        CephUserCredentialPolicies: components["schemas"]["CephUserCredentialPolicies_1_0_0"];
+        /**
+         * DropboxStoragePolicies
+         * @description Connector-specific storage gateway policies for the Dropbox connector
+         *
+         */
+        DropboxStoragePolicies: components["schemas"]["DropboxStoragePolicies_1_0_0"];
+        /**
+         * DropboxCollectionPolicies
+         * @description Connector-specific collection policies for the Dropbox connector
+         *
+         */
+        DropboxCollectionPolicies: components["schemas"]["DropboxCollectionPolicies_1_0_0"];
+        /**
+         * DropboxUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Dropbox connector
+         *
+         */
+        DropboxUserCredentialPolicies: components["schemas"]["DropboxUserCredentialPolicies_1_0_0"];
+        /**
+         * GoogleCloudStoragePolicies
+         * @description Connector-specific storage gateway policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStoragePolicies: components["schemas"]["GoogleCloudStoragePolicies_1_0_0"] | components["schemas"]["GoogleCloudStoragePolicies_1_1_0"];
+        /**
+         * GoogleCloudStorageCollectionPolicies
+         * @description Connector-specific collection policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStorageCollectionPolicies: components["schemas"]["GoogleCloudStorageCollectionPolicies_1_0_0"];
+        /**
+         * GoogleCloudStorageUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Google Cloud Storage
+         *     connector
+         *
+         */
+        GoogleCloudStorageUserCredentialPolicies: components["schemas"]["GoogleCloudStorageUserCredentialPolicies_1_0_0"];
+        /**
+         * GoogleDriveStoragePolicies
+         * @description Connector-specific storage gateway policies for the Google Drive connector
+         *
+         */
+        GoogleDriveStoragePolicies: components["schemas"]["GoogleDriveStoragePolicies_1_0_0"] | components["schemas"]["GoogleDriveStoragePolicies_1_1_0"];
+        /**
+         * GoogleDriveCollectionPolicies
+         * @description Connector-specific collection policies for the Google Drive connector
+         *
+         */
+        GoogleDriveCollectionPolicies: components["schemas"]["GoogleDriveCollectionPolicies_1_0_0"];
+        /**
+         * GoogleDriveUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Google Drive connector
+         *
+         */
+        GoogleDriveUserCredentialPolicies: components["schemas"]["GoogleDriveUserCredentialPolicies_1_0_0"];
+        /** HPSSStoragePolicies */
+        HPSSStoragePolicies: components["schemas"]["HPSSStoragePolicies_1_0_0"] | components["schemas"]["HPSSStoragePolicies_1_1_0"];
+        /**
+         * HPSSCollectionPolicies
+         * @description Connector-specific collection policies for the HPSS connector
+         *
+         */
+        HPSSCollectionPolicies: components["schemas"]["HPSSCollectionPolicies_1_0_0"];
+        /**
+         * HPSSUserCredentialPolicies
+         * @description Connector-specific user credential policies for the HPSS connector
+         *
+         */
+        HPSSUserCredentialPolicies: components["schemas"]["HPSSUserCredentialPolicies_1_0_0"];
+        /**
+         * IrodsStoragePolicies
+         * @description Connector-specific storage gateway policies for the Irods connector
+         *
+         */
+        IrodsStoragePolicies: components["schemas"]["IrodsStoragePolicies_1_0_0"];
+        /**
+         * IrodsCollectionPolicies
+         * @description Connector-specific collection policies for the Irods connector
+         *
+         */
+        IrodsCollectionPolicies: components["schemas"]["IrodsCollectionPolicies_1_0_0"];
+        /**
+         * IrodsUserCredentialPolicies
+         * @description Connector-specific user credential policies for the Irods connector
+         *
+         */
+        IrodsUserCredentialPolicies: components["schemas"]["IrodsUserCredentialPolicies_1_0_0"];
+        /**
+         * OneDriveStoragePolicies
+         * @description Connector-specific storage gateway policies for the OneDrive connector
+         *
+         */
+        OneDriveStoragePolicies: components["schemas"]["OneDriveStoragePolicies_1_0_0"] | components["schemas"]["OneDriveStoragePolicies_1_1_0"];
+        /**
+         * OneDriveCollectionPolicies
+         * @description Connector-specific collection policies for the OneDrive connector
+         *
+         */
+        OneDriveCollectionPolicies: components["schemas"]["OneDriveCollectionPolicies_1_0_0"];
+        /**
+         * OneDriveUserCredentialPolicies
+         * @description Connector-specific user credential policies for the OneDrive connector
+         *
+         */
+        OneDriveUserCredentialPolicies: components["schemas"]["OneDriveUserCredentialPolicies_1_0_0"];
+        /**
+         * PosixStoragePolicies
+         * @description Connector-specific storage gateway policies for the POSIX connector.
+         *
+         */
+        PosixStoragePolicies: components["schemas"]["PosixStoragePolicies_1_0_0"];
+        /**
+         * PosixCollectionPolicies
+         * @description Connector-specific collection policies for the POSIX connector
+         *
+         *
+         *     Version 1.1.0 of the posix_collection_policies document adds the
+         *     **sharing_groups_allow**, and **sharing_groups_deny** properties.
+         *
+         */
+        PosixCollectionPolicies: components["schemas"]["PosixCollectionPolicies_1_0_0"] | components["schemas"]["PosixCollectionPolicies_1_1_0"];
+        /**
+         * PosixUserCredentialPolicies
+         * @description Connector-specific user credential policies for the POSIX connector
+         *
+         */
+        PosixUserCredentialPolicies: components["schemas"]["PosixUserCredentialPolicies_1_0_0"];
+        /**
+         * PosixStagingStoragePolicies
+         * @description Connector-specific storage gateway policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingStoragePolicies: components["schemas"]["PosixStagingStoragePolicies_1_0_0"];
+        /**
+         * PosixStagingCollectionPolicies
+         * @description Connector-specific collection policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingCollectionPolicies: components["schemas"]["PosixStagingCollectionPolicies_1_0_0"];
+        /**
+         * PosixStagingUserCredentialPolicies
+         * @description Connector-specific user credential policies for the POSIX Staging connector
+         *
+         */
+        PosixStagingUserCredentialPolicies: components["schemas"]["PosixStagingUserCredentialPolicies_1_0_0"];
+    };
+    responses: {
+        /** @description Unsupported media type */
+        UnsupportedMediaError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    code?: "unsupported_media_type";
+                    /** @enum {unknown} */
+                    http_response_code?: 415;
+                } & components["schemas"]["Result"];
+            };
+        };
+        /** @description Bad Request */
+        BadRequestError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    code?: "bad_request";
+                    /** @enum {unknown} */
+                    http_response_code?: 400;
+                } & components["schemas"]["Result"];
+            };
+        };
+        /** @description Unprocessable entity */
+        ValidationError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    code?: "unprocessable_entity";
+                    /** @enum {unknown} */
+                    http_response_code?: 422;
+                    detail?: string | components["schemas"]["InvalidInput"];
+                } & components["schemas"]["Result"];
+            };
+        };
+        /** @description Unauthorized */
+        Unauthorized: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    code?: "not_authorized";
+                    /** @enum {unknown} */
+                    http_response_code?: 401;
+                    detail?: string | components["schemas"]["MissingRequiredScopes"];
+                } & components["schemas"]["Result"];
+            };
+        };
+        /** @description Not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    code?: "not_found";
+                    /** @enum {unknown} */
+                    http_response_code?: 404;
+                } & components["schemas"]["Result"];
+            };
+        };
+    };
+    parameters: {
+        /** @description Maximum page size for a paginated response */
+        page_size_query_parameter: number;
+        /** @description Pagination marker for a paginated response */
+        marker_query_parameter: string;
+        /** @description ID of the collection */
+        collection_id_query_parameter: string;
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    postCollectionsBatchDelete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List of collection ids to delete */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Batch"];
+            };
+        };
+        responses: {
+            /** @description Delete multiple collections response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Batch"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"]) | ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["Batch"];
+                    } & components["schemas"]["Result"]);
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    checkCollections: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                /** @description Filter to apply to the return set
+                 *      */
+                filter?: string[];
+                /** @description Filter collections which were created using this storage_gateway_id
+                 *      */
+                storage_gateway_id?: string;
+                /** @description Filter collections which were created using this mapped_collection_id
+                 *      */
+                mapped_collection_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Check collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["CheckResult"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listCollections: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                /** @description Document values to include */
+                include?: "private_policies"[];
+                /** @description Filter to apply to the return set
+                 *      */
+                filter?: string[];
+                /** @description Filter collections which were created using this storage_gateway_id
+                 *      */
+                storage_gateway_id?: string;
+                /** @description Filter collections which were created using this mapped_collection_id
+                 *      */
+                mapped_collection_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Collection"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    postCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Collection definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Collection"];
+            };
+        };
+        responses: {
+            /** @description Create collections response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Collection"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["AuthenticationTimeout"] | components["schemas"]["CredentialNotFound"] | components["schemas"]["IdNotInIdentitySet"] | components["schemas"]["InvalidCredential"] | components["schemas"]["InvalidUser"] | components["schemas"]["MissingRequiredRole"] | components["schemas"]["NotFromAllowedDomain"] | components["schemas"]["SubscriptionRequired"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "conflict";
+                        /** @enum {unknown} */
+                        http_response_code?: 409;
+                        detail?: string | components["schemas"]["ResourceConflict"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    putCollectionOwnerString: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description New collection owner string */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OwnerString"];
+            };
+        };
+        responses: {
+            /** @description Set collection owner string response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteCollectionOwnerString: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete collection owner string response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getCollectionDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get collection domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Domain"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putCollectionDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description New collection domain definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Domain"];
+            };
+        };
+        responses: {
+            /** @description Set collection domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteCollectionDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete collection domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    checkCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Check response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["CheckResult"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    setCollectionOwner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CollectionOwner"];
+            };
+        };
+        responses: {
+            /** @description Set collection owner response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getCollection: {
+        parameters: {
+            query?: {
+                /** @description Document values to include */
+                include?: "private_policies"[];
+            };
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Collection"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description New collection definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Collection"];
+            };
+        };
+        responses: {
+            /** @description Update collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    patchCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the collection */
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Changes to apply to the collection */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Collection"];
+            };
+        };
+        responses: {
+            /** @description Update collections response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    putEndpointSubscriptionId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Endpoint subscription request */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EndpointSubscription"];
+            };
+        };
+        responses: {
+            /** @description Set endpoint owner response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    putEndpointOwnerString: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New endpoint owner_string */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OwnerString"];
+            };
+        };
+        responses: {
+            /** @description Set endpoint owner string response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteEndpointOwnerString: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reset advertised owner string response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    getEndpointDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get endpoint domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    putEndpointDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Put domain request */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Domain"];
+            };
+        };
+        responses: {
+            /** @description Set endpoint domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteEndpointDomain: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete endpoint domain response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    putEndpointOwner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EndpointOwner"];
+            };
+        };
+        responses: {
+            /** @description Set endpoint owner response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get endpoint response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Endpoint"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    putEndpoint: {
+        parameters: {
+            query?: {
+                /** @description List of document types to include in the response */
+                include?: "endpoint"[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New endpoint document */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Endpoint"];
+            };
+        };
+        responses: {
+            /** @description Update endpoint response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Endpoint"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    patchEndpoint: {
+        parameters: {
+            query?: {
+                /** @description List of document types to include in the response */
+                include?: "endpoint"[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Changes to the Endpoint document */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Endpoint"];
+            };
+        };
+        responses: {
+            /** @description Update endpoint response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Endpoint"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getInfo: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get info response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: (components["schemas"]["Connector"] | components["schemas"]["Info"])[];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    listNodes: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List nodes response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Node"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    postNode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New node definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Node"];
+            };
+        };
+        responses: {
+            /** @description Create node response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Node"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"]) | ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["LimitExceeded"];
+                    } & components["schemas"]["Result"]);
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getNode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the node */
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get node response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Node"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putNode: {
+        parameters: {
+            query?: {
+                /** @description Flag indicating whether to request all roles assignments for the endpoint
+                 *     or collection.
+                 *      */
+                include?: "node"[];
+            };
+            header?: never;
+            path: {
+                /** @description Id of the node */
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description New node definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Node"];
+            };
+        };
+        responses: {
+            /** @description Update node response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Node"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteNode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the node */
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete node response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    patchNode: {
+        parameters: {
+            query?: {
+                /** @description Flag indicating whether to request all roles assignments for the endpoint
+                 *     or collection.
+                 *      */
+                include?: "node"[];
+            };
+            header?: never;
+            path: {
+                /** @description Id of the node */
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updates to node definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Node"];
+            };
+        };
+        responses: {
+            /** @description Update node response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Node"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listRoles: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                /** @description ID of the collection */
+                collection_id?: components["parameters"]["collection_id_query_parameter"];
+                /** @description Flag indicating whether to request all roles assignments for the endpoint
+                 *     or collection.
+                 *      */
+                include?: "all_roles"[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List roles response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Role"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    postRoles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New role assignment document */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Role"];
+            };
+        };
+        responses: {
+            /** @description Create role response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Role"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "bad_request";
+                        /** @enum {unknown} */
+                        http_response_code?: 400;
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"]) | ({
+                        /** @enum {string} */
+                        code?: "subscription_required";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["SubscriptionRequired"];
+                    } & components["schemas"]["Result"]);
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "exists";
+                        /** @enum {unknown} */
+                        http_response_code?: 409;
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getRole: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the role */
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get role response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["Role"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteRole: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the role */
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete role response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": ({
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"]) | ({
+                        /** @enum {string} */
+                        code?: "subscription_required";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["SubscriptionRequired"];
+                    } & components["schemas"]["Result"]);
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "conflict";
+                        /** @enum {unknown} */
+                        http_response_code?: 409;
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    listSharingPolicies: {
+        parameters: {
+            query: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                /** @description Username to query information about */
+                username?: string;
+                /** @description ID of the collection */
+                collection_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List sharing policies response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["SharingPolicy"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    postSharingPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New sharing policy */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SharingPolicy"];
+            };
+        };
+        responses: {
+            /** @description List sharing policies response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["SharingPolicy"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getSharingPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the sharing policy */
+                sharing_policy_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get sharing policy response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["SharingPolicy"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteSharingPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the sharing policy */
+                sharing_policy_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete sharing policy response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listStorageGateways: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                include?: ("private_policies" | "accounts")[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List storage gateways response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["StorageGateway"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    postStorageGateway: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New storage gateway definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StorageGateway"];
+            };
+        };
+        responses: {
+            /** @description Post storage gateways response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["StorageGateway"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getStorageGateway: {
+        parameters: {
+            query?: {
+                include?: ("private_policies" | "accounts")[];
+            };
+            header?: never;
+            path: {
+                /** @description Id of the storage gateway */
+                storage_gateway_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get storage gateways response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["StorageGateway"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putStorageGateway: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the storage gateway */
+                storage_gateway_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated storage gateway definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StorageGateway"];
+            };
+        };
+        responses: {
+            /** @description Update storage gateway response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["StorageGateway"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteStorageGateway: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the storage gateway */
+                storage_gateway_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get storage gateways response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    patchStorageGateway: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the storage gateway */
+                storage_gateway_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updates to the storage gateway definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StorageGateway"];
+            };
+        };
+        responses: {
+            /** @description Update storage gateway response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["StorageGateway"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["MissingRequiredRole"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listUserCredentials: {
+        parameters: {
+            query?: {
+                /** @description Maximum page size for a paginated response */
+                page_size?: components["parameters"]["page_size_query_parameter"];
+                /** @description Pagination marker for a paginated response */
+                marker?: components["parameters"]["marker_query_parameter"];
+                /** @description Credentials to include. If set to **all**, then -
+                 *     credentials owned by other users are returned if the storage gateway allows
+                 *     admin_managed_credentials and the caller has an endpoint:administrator or
+                 *     endpoint:owner role.
+                 *      */
+                include?: "all"[];
+                /** @description ID of the Storage Gateway */
+                storage_gateway?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List user credential response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["UserCredential"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    postUserCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description New user credential definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserCredential"];
+            };
+        };
+        responses: {
+            /** @description Create user credential response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["UserCredential"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getUserCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the user credential */
+                user_credential_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get user credential response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["UserCredential"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["NotResourceOwner"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putUserCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the user credential */
+                user_credential_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated user credential definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserCredential"];
+            };
+        };
+        responses: {
+            /** @description Update user credential response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["UserCredential"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["NotResourceOwner"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteUserCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the user credential */
+                user_credential_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete user credential response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["NotResourceOwner"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    patchUserCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Id of the user credential */
+                user_credential_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Changes to the user credential definition */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserCredential"];
+            };
+        };
+        responses: {
+            /** @description Update user credential response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "success";
+                        data?: components["schemas"]["UserCredential"][];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code?: "permission_denied";
+                        /** @enum {unknown} */
+                        http_response_code?: 403;
+                        detail?: string | components["schemas"]["NotResourceOwner"];
+                    } & components["schemas"]["Result"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getAuthcallbackGoogle: {
+        parameters: {
+            query: {
+                /** @description OAuth code response */
+                code?: string;
+                /** @description Error information from the OAuth provider */
+                error?: string;
+                /** @description Encrypted authorization context */
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to page initiating the credential creation */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequestError"];
+        };
+    };
+    postUserCredentials: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description User credential request */
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["OAuthUserCredentialForm"];
+            };
+        };
+        responses: {
+            /** @description Redirection to OAuth flow */
+            303: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequestError"];
+            401: components["responses"]["Unauthorized"];
+            415: components["responses"]["UnsupportedMediaError"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getAuthclicomplete: {
+        parameters: {
+            query?: {
+                /** @description Unique identifier of the new credential */
+                user_credential_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authentication callback response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Result"];
+                };
+            };
+        };
+    };
+    getAuthcallback: {
+        parameters: {
+            query: {
+                /** @description OAuth code response */
+                code?: string;
+                /** @description Error information from the OAuth provider */
+                error?: string;
+                /** @description Encrypted authorization context */
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to page initiating the credential creation */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequestError"];
+        };
+    };
+}

--- a/src/open-api/types/groups.d.ts
+++ b/src/open-api/types/groups.d.ts
@@ -1,0 +1,2244 @@
+export interface paths {
+    "/v2/groups/my_groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve your groups and memberships
+         * @description This endpoint returns, as an array, all groups in which the user and
+         *     its linked identities is an active member, manager, or admin, by default.
+         *
+         *     The my_memberships field is included by default.
+         *
+         *     The optional query parameter, `statuses`, results in the array containing
+         *     those memberships with one of the specified status(es). The default value
+         *     is `active`.
+         */
+        get: operations["get_my_groups_and_memberships_v2_groups_my_groups_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups/statuses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the status counts of memberships for each group you are an admin or manager of.
+         * @description This endpoint retreives all the membership counts for groups where the caller is
+         *     either an admin or manager.
+         */
+        get: operations["get_statuses_v2_groups_statuses_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups/{group_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Group
+         * @description Get details and members of a group by group id.
+         *
+         *     If `memberships` or `my_memberships` are in the `include` parameter and the
+         *     scopes in the provided authorization token allow memberships to be viewed,
+         *     the memberships will be returned in the response.
+         *
+         *     If `allowed_actions` are in the `include` parameter, and the scopes in the
+         *     tokens allow managing memberships, an object will be returned detailing which
+         *     membership actions each identity in the user's set is allowed to perform.
+         *
+         *     A group can be viewed if:
+         *     - The group policy is that any authenticated user can view it.
+         *     - The group is private, and the user has an active/invited/pending membership.
+         *
+         *     Group memberships can only be viewed by active members. Depending on group policy,
+         *     this may be further restricted to only admins and managers. Note that future
+         *     versions may relax this restriction for specific cases, such as allowing invited
+         *     or pending members to view the membership of the user that invited them.
+         */
+        get: operations["get_group_v2_groups__group_id__get"];
+        /**
+         * Update an existing group
+         * @description Update the details of a group by group id.
+         *
+         *     If `allowed_actions` are in the `include` parameter, and the scopes in the
+         *     tokens allow managing memberships, an object will be returned detailing which
+         *     membership actions each identity in the user's set is allowed to perform.
+         *
+         *     A group can be updated if:
+         *     - The user is an admin.
+         *
+         *     Group memberships should be updated using the membership endpoint.
+         */
+        put: operations["update_group_v2_groups__group_id__put"];
+        /**
+         * Perform actions on members of the group.
+         * @description This endpoint supports bulk actions on collections of members of the group.
+         *     Currently the following actions are supported:
+         *
+         *     - **accept**: Identities in the `accept` list which are in the users identity set
+         *       will be accepted into the group. Only `invited` memberships can `accept`.
+         *     - **add**: Identities in the `add` list will be added to the group as long
+         *       as the identity exists and they have not previously left the group, or indicated
+         *       via settings that they can not be added to any group. Adding an identity which
+         *       already have an active membership in the group will not modify the membership,
+         *       and is an error for informational purposes. All active admins and managers are
+         *       permitted to add members to a group. Active admins are also permitted to add
+         *       admins and managers to a group.  Role is an optional parameter to set the
+         *       membership role on addition.
+         *     - **approve**: Identities in the `approve` list will be
+         *       accepted into the group. Only `pending` memberships can be included in
+         *       the `approve` list. All active admins and managers are permitted to approve
+         *       pending members to a group.
+         *     - **change_role**: Identities in the `change_role` list whose roles in the group are
+         *       to be updated.  Only admins can change member roles.  Only `active` memberships
+         *       are eligible for role changes.
+         *     - **decline**: Identities in the `decline` list which are in the users identity set
+         *       will be rejected from the group. Only `invited` memberships can `decline`.
+         *     - **invite**:  Identities in the `invite` list will be invited to join the group.
+         *       All active admins and managers are permitted to invite members to a group. Members
+         *       may also invite other members if the policy allows it. Role is an optional
+         *       parameter to set the membership role on invitation.
+         *     - **join**: Identities in the `join` list which are in the users identity set
+         *       will join the group, if the group policy is to allow users to join. High Assurance
+         *       groups cannot use this action.
+         *     - **leave**: Identities in the `leave` list which are in the users identity set
+         *       will be removed from the group. Only `active` memberships can `leave`. If the
+         *       identity is the last remaining `admin` of the group leaving is not allowed,
+         *       since this would leave the group in an orphaned state.
+         *     - **reject**: Identities in the `reject` list will be
+         *       rejected from the group. Only `pending` memberships can be included in
+         *       the `reject` list. All active admins and managers are permitted to reject pending
+         *       members from a group.
+         *     - **remove**: Identities in the `remove` list will be removed from the group.
+         *       Admins can remove admins, managers, and members. Managers can remove managers and
+         *       members. Regular members cannot remove any members. Only `active` and `invited`
+         *       memberships can be removed, and users cannot remove their own memberships.
+         *     - **request_join**: Identities in the `request_join` list which are in the users
+         *       identity set will be set as pending memberships for the group if the group policy
+         *       requires membership approval. Pending memberships must be approved or rejected by
+         *       administrators or managers.
+         *
+         *     The response will include the current state of any membership that was
+         *     successfully processed. The response will also include a list of errors
+         *     indicating the identity of any requested membership action that failed to
+         *     be processed.
+         *
+         *     Identity IDs must be unique across all actions in the same call. For example,
+         *     trying to add and remove the same identity in the same request will cause the
+         *     entire request to fail.
+         */
+        post: operations["group_membership_post_actions_v2_groups__group_id__post"];
+        /**
+         * Delete a group
+         * @description This endpoint allows a group to be deleted by an admin.
+         *
+         *     > Note: Groups can only be deleted by admins.
+         */
+        delete: operations["delete_group_v2_groups__group_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups/{group_id}/children": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Children
+         * @description Get the children of the group.
+         */
+        get: operations["get_children_v2_groups__group_id__children_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a new group
+         * @description MVP limitations:
+         *
+         *     - For users with more than one linked identity, ability to specify
+         *     which identity becomes the admin will be added later.
+         *     - Non-default policies can not be specified. They can be adjusted using the
+         *     Globus web app.
+         *
+         *     Create a new group with the given name. The effective identity (typically
+         *     the user's primary identity) of the Auth token used for the call will be
+         *     added to the group as an administrator. The group will be created with
+         *     default polices that:
+         *
+         *     * Allow membership requests only to be approved by admins and managers
+         *     * Allow subgroups to be created only by admins
+         *     * Allow the group to be visible only to members
+         *     * Allow member names to be visible only to managers and admins
+         *     * Allow invititations to be sent by managers and admins
+         *     * Disallow requests to join
+         *
+         *     Groups can only be created by users with 1000 or fewer active memberships.
+         */
+        post: operations["create_group_v2_groups_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups/{group_id}/policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the policies for the group.
+         * @description Get the policies for a group.
+         */
+        get: operations["get_policies_v2_groups__group_id__policies_get"];
+        /**
+         * Set the policies for the group.
+         * @description Update the policies for a group.
+         */
+        put: operations["update_policies_v2_groups__group_id__policies_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the preferences for your identity set.
+         * @description This endpoint allows users to get preferences for each of their
+         *      identities that affect how their identity can be used in groups.
+         *       Currently, the supported preferences are:
+         *
+         *     - **allow_add**: Whether or not an identity can be added
+         */
+        get: operations["get_identity_set_preferences_v2_preferences_get"];
+        /**
+         * Set the preferences for your identity set.
+         * @description This endpoint allows users to set preferences for each of their
+         *      identities that affect how their identity can be used in groups.
+         *       Currently, the supported preferences are:
+         *
+         *     - **allow_add**: Whether or not an identity can be added
+         */
+        put: operations["put_identity_set_preferences_v2_preferences_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/groups/{group_id}/membership_fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the membership fields for your identity set.
+         * @description This endpoint allows users to get preferences for each of their identities
+         *      that affect how their identity can be used in groups. Currently, the
+         *      supported preferences are:
+         */
+        get: operations["get_membership_fields_v2_groups__group_id__membership_fields_get"];
+        /**
+         * Set the membership fields for your identity set.
+         * @description This endpoint allows users to set preferences for each of their identities
+         *      that affect how their identity can be used in groups. Currently, the supported
+         *      preferences are:
+         */
+        put: operations["put_membership_fields_v2_groups__group_id__membership_fields_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/subscription_info/{subscription_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get groups by subscription_id
+         * @description This endpoint allows users to retrieve limited information about all groups that
+         *     have the given subscription_id. Currently, the fields returned for each group are:
+         *
+         *     - **group_id**: The unique UUID for the group
+         *     - **subscription_id**: The unique UUID for the subscription; identical to the id
+         *       provided in the request
+         *     - **subscription_info**: Basic information about the subscription; excludes the
+         *       subscription name for privacy purposes
+         */
+        get: operations["get_group_by_subscription_id_v2_subscription_info__subscription_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /**
+         * AllowedActionsModel
+         * @description Specifies which identities associated with the current token, if any, are
+         *     in principle allowed to perform various actions.
+         *
+         *     Attempting to perform an action which no identity has permissions for is a
+         *     transactional error, and the entire request will fail.
+         */
+        AllowedActionsModel: {
+            /**
+             * Add
+             * @description User's identities which are allowed to add members to the group.
+             */
+            add: string[];
+            /**
+             * Change Role
+             * @description User's identities which are allowed to change group members' roles.
+             */
+            change_role: string[];
+            /**
+             * Invite
+             * @description User's identities which are allowed to invite members to the group.
+             */
+            invite: string[];
+            /**
+             * Remove
+             * @description User's identities which are allowed to remove members from the group.
+             */
+            remove: string[];
+            /**
+             * Join
+             * @description User's identities which can join the group, becoming active members.
+             */
+            join: string[];
+            /**
+             * Request Join
+             * @description User's identities which can request to join the group, pending admin/manager approval.
+             */
+            request_join: string[];
+            /**
+             * Approve
+             * @description Identities that are approved to join the group.
+             */
+            approve: string[];
+            /**
+             * Reject
+             * @description Identities that are rejected from joining the group.
+             */
+            reject: string[];
+            /**
+             * Accept
+             * @description User's identities which can accept an invitation to the group, pending admin/manager approval.
+             */
+            accept: string[];
+            /**
+             * Leave
+             * @description User's active identities which can leave the group.
+             */
+            leave: string[];
+            /**
+             * Decline
+             * @description User's invited identities which can decline an invitation.
+             */
+            decline: string[];
+        };
+        /** AuthErrorModel */
+        AuthErrorModel: {
+            /**
+             * Code
+             * @description A machine parsable string representing the type of error.
+             */
+            code: string;
+            /**
+             * Detail
+             * @description A human readable explanation of the error.
+             */
+            detail: string;
+            /** @description Additional fields in compliance with the Globus Auth Requirements Error format. */
+            authorization_parameters: components["schemas"]["AuthParamsModel"];
+        };
+        /** AuthParamsModel */
+        AuthParamsModel: {
+            /**
+             * Session Message
+             * @description A message to be displayed to the user.
+             */
+            session_message?: string;
+            /**
+             * Session Required Identities
+             * @description A list of identities required for the session.
+             */
+            session_required_identities?: string[];
+            /**
+             * Session Required Policies
+             * @description A list of policies required for the session.
+             */
+            session_required_policies?: string[];
+            /**
+             * Session Required Single Domain
+             * @description A list of domains required for the session.
+             */
+            session_required_single_domain?: string[];
+            /**
+             * Session Required Mfa
+             * @description Whether MFA is required for the session.
+             */
+            session_required_mfa?: boolean;
+            /**
+             * Required Scopes
+             * @description A list of scopes for which consent is required.
+             */
+            required_scopes?: string[];
+            /**
+             * Extra
+             * @description A dictionary of additional fields that were provided.
+             */
+            extra?: Record<string, unknown>;
+        };
+        /** BadRequestErrorModel */
+        BadRequestErrorModel: {
+            /**
+             * Code
+             * @description A machine parsable string representing the type of error.
+             */
+            code: string;
+            /**
+             * Detail
+             * @description A human readable explanation of the error.
+             */
+            detail: string;
+            /**
+             * Ambiguous Identities
+             * @description List of duplicate identities that caused the exception.
+             */
+            ambiguous_identities: string[];
+        };
+        /** BaseErrorModel */
+        BaseErrorModel: {
+            /**
+             * Code
+             * @description A machine parsable string representing the type of error.
+             */
+            code: string;
+            /**
+             * Detail
+             * @description A human readable explanation of the error.
+             */
+            detail: string;
+        };
+        /** ConnectorSubscriptionInfo */
+        ConnectorSubscriptionInfo: {
+            /**
+             * Is Ha
+             * @description True if HA connector subscription.
+             */
+            is_ha: boolean;
+            /**
+             * Is Baa
+             * @description True if BAA connector subscription.
+             */
+            is_baa: boolean;
+        };
+        /** ForbiddenErrorModel */
+        ForbiddenErrorModel: {
+            /**
+             * Code
+             * @description A machine parsable string representing the type of error.
+             */
+            code: string;
+            /**
+             * Detail
+             * @description A human readable explanation of the error.
+             */
+            detail: string;
+            /**
+             * Provided Scopes
+             * @description List of all scopes provided to the user.
+             */
+            provided_scopes?: string[] | null;
+        };
+        /** GroupChildrenReadModel */
+        GroupChildrenReadModel: {
+            /**
+             * Children
+             * @description The children of the group.
+             */
+            children: components["schemas"]["GroupReadModel"][];
+        };
+        /** GroupCreateModel */
+        GroupCreateModel: {
+            /**
+             * Description
+             * @description The description of the group.
+             */
+            description?: string | null;
+            /**
+             * Terms And Conditions
+             * @description The terms and conditions for group membership
+             */
+            terms_and_conditions?: string | null;
+            /**
+             * Name
+             * @description The name of the group.
+             */
+            name: string;
+            /**
+             * Parent Id
+             * @description The ID of the parent of the group to be created.  The identity creating this group must be an admin of the parent group.
+             */
+            parent_id?: string | null;
+            /** @description Policies for the group regarding members etc. */
+            policies?: components["schemas"]["GroupPolicyWriteModel"];
+        };
+        /**
+         * GroupMemberVisibilityPolicyEnum
+         * @description Who can view group memberships.
+         *
+         *     - **members**: All members of the group.
+         *     - **managers**: Only admins and managers.
+         * @enum {string}
+         */
+        GroupMemberVisibilityPolicyEnum: "members" | "managers";
+        /** GroupMembershipPostAction */
+        GroupMembershipPostAction: {
+            /**
+             * Accept
+             * @description List of identities that have been invited and should be accepted to the group.
+             */
+            accept?: components["schemas"]["MembershipActionStatusModel"][] | null;
+            /**
+             * Add
+             * @description List of identities to add as active members of the group
+             */
+            add?: components["schemas"]["MembershipActionStatusAndRoleModel"][] | null;
+            /**
+             * Change Role
+             * @description List of identities whose roles are to be changed
+             */
+            change_role?: components["schemas"]["MembershipsActionChangeRoleModel"][] | null;
+            /**
+             * Decline
+             * @description List of identities that are declining an invitation to join.
+             */
+            decline?: components["schemas"]["MembershipActionStatusModel"][] | null;
+            /**
+             * Invite
+             * @description List of identities to invite to the group.
+             */
+            invite?: components["schemas"]["MembershipActionInviteModel"][] | null;
+            /**
+             * Leave
+             * @description List of user's active memberships to leave the group
+             */
+            leave?: components["schemas"]["MembershipActionStatusModel"][] | null;
+            /**
+             * Join
+             * @description List of identities that will join the group if policies allow directly joining.  These must be identities in the authenticated user's identity set.
+             */
+            join?: components["schemas"]["MembershipActionBaseModel"][] | null;
+            /**
+             * Remove
+             * @description List of identities to remove from the group
+             */
+            remove?: components["schemas"]["MembershipActionStatusModel"][] | null;
+            /**
+             * Request Join
+             * @description List of identities that are requesting to join the group. These must be identities in the authenticated user's identity set.
+             */
+            request_join?: components["schemas"]["MembershipActionBaseModel"][] | null;
+            /**
+             * Approve
+             * @description List of pending identities that will be approved to join the group.
+             */
+            approve?: components["schemas"]["MembershipActionStatusModel"][] | null;
+            /**
+             * Reject
+             * @description List of pending identities that will be rejected from joining the group.
+             */
+            reject?: components["schemas"]["MembershipActionStatusModel"][] | null;
+        };
+        /** GroupMembershipPostActionErrors */
+        GroupMembershipPostActionErrors: {
+            /** Accept */
+            accept?: components["schemas"]["MembershipError"][] | null;
+            /** Add */
+            add?: components["schemas"]["MembershipError"][] | null;
+            /** Change Role */
+            change_role?: components["schemas"]["MembershipError"][] | null;
+            /** Decline */
+            decline?: components["schemas"]["MembershipError"][] | null;
+            /** Invite */
+            invite?: components["schemas"]["MembershipError"][] | null;
+            /** Join */
+            join?: components["schemas"]["MembershipError"][] | null;
+            /** Leave */
+            leave?: components["schemas"]["MembershipError"][] | null;
+            /** Remove */
+            remove?: components["schemas"]["MembershipError"][] | null;
+            /** Request Join */
+            request_join?: components["schemas"]["MembershipError"][] | null;
+            /** Approve */
+            approve?: components["schemas"]["MembershipError"][] | null;
+            /** Reject */
+            reject?: components["schemas"]["MembershipError"][] | null;
+        };
+        /** GroupMembershipPostActionResponse */
+        GroupMembershipPostActionResponse: {
+            /** Accept */
+            accept?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Add */
+            add?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Change Role */
+            change_role?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Decline */
+            decline?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Invite */
+            invite?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Join */
+            join?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Leave */
+            leave?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Remove */
+            remove?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Request Join */
+            request_join?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Approve */
+            approve?: components["schemas"]["MembershipReadModel"][] | null;
+            /** Reject */
+            reject?: components["schemas"]["MembershipReadModel"][] | null;
+            errors?: components["schemas"]["GroupMembershipPostActionErrors"] | null;
+        };
+        /** GroupPolicyReadModel */
+        GroupPolicyReadModel: {
+            /** Is High Assurance */
+            is_high_assurance: boolean;
+            /**
+             * Authentication Assurance Timeout
+             * @description Maximum allowed seconds before a user must reauthenticate to access the group if is set to High Assurance. Defaults to 28800 for HA groups.
+             */
+            authentication_assurance_timeout?: number | null;
+            group_visibility: components["schemas"]["GroupVisibilityPolicyEnum"];
+            group_members_visibility: components["schemas"]["GroupMemberVisibilityPolicyEnum"];
+            /**
+             * Join Requests
+             * @description If true then users may request to join the group.
+             */
+            join_requests?: boolean;
+            /** Signup Fields */
+            signup_fields: components["schemas"]["SignupFieldsEnum"][];
+        };
+        /** GroupPolicyWriteModel */
+        GroupPolicyWriteModel: {
+            /** Is High Assurance */
+            is_high_assurance?: boolean | null;
+            /**
+             * Authentication Assurance Timeout
+             * @description Maximum allowed seconds before a user must reauthenticate to access the group if is set to High Assurance. Defaults to 28800 for HA groups.
+             */
+            authentication_assurance_timeout?: number | null;
+            group_visibility?: components["schemas"]["GroupVisibilityPolicyEnum"] | null;
+            group_members_visibility?: components["schemas"]["GroupMemberVisibilityPolicyEnum"] | null;
+            /**
+             * Join Requests
+             * @description If true then users may request to join the group.
+             */
+            join_requests?: boolean | null;
+            /** Signup Fields */
+            signup_fields?: components["schemas"]["SignupFieldsEnum"][] | null;
+        };
+        /** GroupReadModel */
+        GroupReadModel: {
+            /**
+             * Description
+             * @description The description of the group.
+             */
+            description?: string | null;
+            /**
+             * Terms And Conditions
+             * @description The terms and conditions for group membership
+             */
+            terms_and_conditions?: string | null;
+            /**
+             * Name
+             * @description The name of the group.
+             */
+            name: string;
+            /**
+             * Id
+             * Format: uuid
+             * @description The ID of the group.
+             */
+            id: string;
+            /**
+             * @description The type of group (regular or Globus Plus).
+             * @default regular
+             */
+            group_type: components["schemas"]["GroupTypeEnum"];
+            /**
+             * Child Ids
+             * @description IDs of the children groups (some of the groups in this list might be private).
+             */
+            child_ids?: string[] | null;
+            /**
+             * Enforce Session
+             * @default false
+             */
+            enforce_session: boolean;
+            /**
+             * Session Limit
+             * @description Number of seconds required for most recent authentication token
+             */
+            session_limit?: number | null;
+            /**
+             * Session Timeouts
+             * @description A mapping of identity_ids to data about when that identity's authentication falls out of this group's session limit. Only identities in the session will be included here.
+             * @default {}
+             */
+            session_timeouts: {
+                [key: string]: components["schemas"]["TimeoutData"];
+            };
+            /**
+             * My Memberships
+             * @description Optional list of memberships the authenticated user has in the group.
+             */
+            my_memberships?: components["schemas"]["MembershipReadModel"][] | null;
+            /**
+             * Memberships
+             * @description Optional list of all memberships in the group.
+             */
+            memberships?: components["schemas"]["MembershipReadModel"][] | null;
+            /** @description The actions allowed for the authenticated user's identities. This is intended to assist clients in determining which actions are possible for a given user. */
+            allowed_actions?: components["schemas"]["AllowedActionsModel"] | null;
+            /**
+             * Subscription Id
+             * @description The subscription ID
+             */
+            subscription_id?: string | null;
+            /** @description Detailed information regarding the subscription. */
+            subscription_info?: components["schemas"]["SubscriptionModel"] | null;
+            /** @description Policies for the group regarding members etc. */
+            policies?: components["schemas"]["GroupPolicyReadModel"];
+            /**
+             * Parent Id
+             * @description The ID of the parent of the group to be created.  The identity creating this group must be an admin of the parent group.
+             */
+            parent_id: string | null;
+        };
+        /** GroupStatusCounts */
+        GroupStatusCounts: {
+            /**
+             * Active
+             * @description Count of active group members
+             * @default 0
+             */
+            active: number;
+            /**
+             * Invited
+             * @description Count of identities invited to join the group.
+             * @default 0
+             */
+            invited: number;
+            /**
+             * Pending
+             * @description Count of identities pending acceptance to join the group.
+             * @default 0
+             */
+            pending: number;
+            /**
+             * Rejected
+             * @description Count of indentities that were rejected.
+             * @default 0
+             */
+            rejected: number;
+            /**
+             * Removed
+             * @description Count of former group members who were removed.
+             * @default 0
+             */
+            removed: number;
+            /**
+             * Left
+             * @description Count of former group members who left the group.
+             * @default 0
+             */
+            left: number;
+            /**
+             * Declined
+             * @description Count of declined group members.
+             * @default 0
+             */
+            declined: number;
+        };
+        /** GroupSubscriptionModel */
+        GroupSubscriptionModel: {
+            /**
+             * Group Id
+             * Format: uuid
+             * @description The ID of the group.
+             */
+            group_id: string;
+            /**
+             * Subscription Id
+             * Format: uuid
+             * @description The subscription ID
+             */
+            subscription_id: string;
+            /** @description Detailed information regarding the subscription. */
+            subscription_info: components["schemas"]["SubscriptionModelLimited"];
+        };
+        /**
+         * GroupTypeEnum
+         * @enum {string}
+         */
+        GroupTypeEnum: "regular" | "plus";
+        /**
+         * GroupVisibilityPolicyEnum
+         * @description Who can view the group.
+         *
+         *     - **authenticated**: Any authenticated user.
+         *     - **private**: Only active/invited/pending members of the group.
+         * @enum {string}
+         */
+        GroupVisibilityPolicyEnum: "authenticated" | "private";
+        /** GroupWriteModel */
+        GroupWriteModel: {
+            /**
+             * Description
+             * @description The description of the group.
+             */
+            description?: string | null;
+            /**
+             * Terms And Conditions
+             * @description The terms and conditions for group membership
+             */
+            terms_and_conditions?: string | null;
+            /**
+             * Name
+             * @description The name of the group.
+             */
+            name?: string | null;
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /** IdentityPreferences */
+        IdentityPreferences: {
+            /**
+             * Allow Add
+             * @description If false, then this identity can not be added directly to a group by an admin.
+             */
+            allow_add: boolean | null;
+        };
+        /** MembershipActionBaseModel */
+        MembershipActionBaseModel: {
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user whose membership is being created or updated.
+             */
+            identity_id: string;
+        };
+        /** MembershipActionInviteModel */
+        MembershipActionInviteModel: {
+            /**
+             * @description The membership role for the user that is being added, invited, or changed.
+             * @default member
+             */
+            role: components["schemas"]["RoleEnum"] | null;
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user whose membership is being created or updated.
+             */
+            identity_id: string;
+            /**
+             * Status Reason
+             * @description The reason provided when changing the member status.
+             */
+            status_reason?: string | null;
+            /**
+             * Invite Email Address
+             * @description Send the group invitation to the specified email address.
+             */
+            invite_email_address?: string | null;
+        };
+        /** MembershipActionStatusAndRoleModel */
+        MembershipActionStatusAndRoleModel: {
+            /**
+             * @description The membership role for the user that is being added, invited, or changed.
+             * @default member
+             */
+            role: components["schemas"]["RoleEnum"] | null;
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user whose membership is being created or updated.
+             */
+            identity_id: string;
+            /**
+             * Status Reason
+             * @description The reason provided when changing the member status.
+             */
+            status_reason?: string | null;
+        };
+        /** MembershipActionStatusModel */
+        MembershipActionStatusModel: {
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user whose membership is being created or updated.
+             */
+            identity_id: string;
+            /**
+             * Status Reason
+             * @description The reason provided when changing the member status.
+             */
+            status_reason?: string | null;
+        };
+        /** MembershipError */
+        MembershipError: {
+            /**
+             * Identity Id
+             * @description The identity from the request that caused the error.
+             */
+            identity_id: string;
+            /**
+             * Code
+             * @description A machine parsable string representing the type of error.
+             */
+            code: string;
+            /**
+             * Detail
+             * @description A human readable explanation of the error.
+             */
+            detail: string;
+        };
+        /** MembershipFields */
+        MembershipFields: {
+            /** First Name */
+            first_name?: string | null;
+            /** Last Name */
+            last_name?: string | null;
+            /** Organization */
+            organization?: string | null;
+            /** Institution */
+            institution?: string | null;
+            /** Current Project Name */
+            current_project_name?: string | null;
+            /** Address */
+            address?: string | null;
+            /** City */
+            city?: string | null;
+            /** State */
+            state?: string | null;
+            /** Country */
+            country?: string | null;
+            /** Address1 */
+            address1?: string | null;
+            /** Address2 */
+            address2?: string | null;
+            /** Zip */
+            zip?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Department */
+            department?: string | null;
+            /** Field Of Science */
+            field_of_science?: string | null;
+        };
+        /** MembershipReadModel */
+        MembershipReadModel: {
+            /**
+             * Group Id
+             * Format: uuid
+             * @description The id of the group the member belongs to.
+             */
+            group_id: string;
+            /**
+             * Source Group Id
+             * Format: uuid
+             * @description The subgroup that the identity is a member of causing membership to be implied in this group.
+             */
+            source_group_id?: string;
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user that is a member.
+             */
+            identity_id: string;
+            /**
+             * Username
+             * @description The username of the user that is a member.
+             */
+            username: string;
+            /** @description The role of the member in the group. */
+            role: components["schemas"]["RoleEnum"];
+            /** @description The status of the member in the group. */
+            status: components["schemas"]["StatusEnum"];
+            /**
+             * Status Reason
+             * @description The reason provided when changing the member status.
+             */
+            status_reason?: string | null;
+            /**
+             * Invite Email Address
+             * @description Email address for the group invitation.
+             */
+            invite_email_address?: string | null;
+            /**
+             * Updated
+             * @description RFC 8601 format date and time when the membership was last updated.
+             */
+            updated?: string | null;
+            /**
+             * Invite Time
+             * @description RFC 8601 format date and time when the user was invited to the group.
+             */
+            invite_time?: string | null;
+            /**
+             * Membership Fields
+             * @description The additional sign-up fields required by the group.
+             * @default {}
+             */
+            membership_fields: Record<string, unknown> | null;
+        };
+        /** MembershipsActionChangeRoleModel */
+        MembershipsActionChangeRoleModel: {
+            /**
+             * @description The membership role for the user that is being added, invited, or changed.
+             * @default member
+             */
+            role: components["schemas"]["RoleEnum"] | null;
+            /**
+             * Identity Id
+             * Format: uuid
+             * @description The identity of the user whose membership is being created or updated.
+             */
+            identity_id: string;
+        };
+        /**
+         * RoleEnum
+         * @enum {string}
+         */
+        RoleEnum: "member" | "manager" | "admin";
+        /**
+         * SignupFieldsEnum
+         * @description The available signup fields.
+         * @enum {string}
+         */
+        SignupFieldsEnum: "institution" | "current_project_name" | "address" | "city" | "state" | "country" | "address1" | "address2" | "zip" | "phone" | "department" | "field_of_science";
+        /**
+         * StatusEnum
+         * @enum {string}
+         */
+        StatusEnum: "active" | "invited" | "pending" | "rejected" | "removed" | "left" | "declined";
+        /** SubscriptionModel */
+        SubscriptionModel: {
+            /**
+             * Name
+             * @description The subscription name.
+             */
+            name: string;
+            /**
+             * Subscriber Name
+             * @description The subscriber's name.
+             */
+            subscriber_name: string;
+            /**
+             * Is High Assurance
+             * @description True if HA subscriber.
+             * @default false
+             */
+            is_high_assurance: boolean;
+            /**
+             * Is Baa
+             * @description True if BAA subscriber.
+             * @default false
+             */
+            is_baa: boolean;
+            /**
+             * Connectors
+             * @description A mapping of connector UUIDs to connector subscription data.
+             * @default {}
+             */
+            connectors: {
+                [key: string]: components["schemas"]["ConnectorSubscriptionInfo"];
+            };
+        };
+        /** SubscriptionModelLimited */
+        SubscriptionModelLimited: {
+            /**
+             * Is High Assurance
+             * @description True if HA subscriber.
+             * @default false
+             */
+            is_high_assurance: boolean;
+            /**
+             * Is Baa
+             * @description True if BAA subscriber.
+             * @default false
+             */
+            is_baa: boolean;
+            /**
+             * Connectors
+             * @description A mapping of connector UUIDs to connector subscription data.
+             * @default {}
+             */
+            connectors: {
+                [key: string]: components["schemas"]["ConnectorSubscriptionInfo"];
+            };
+        };
+        /** TimeoutData */
+        TimeoutData: {
+            /**
+             * Expire Time
+             * Format: date-time
+             * @description RFC 8601 format date and time when the identity will have passed the session limit
+             */
+            expire_time: string;
+            /**
+             * Expires In
+             * @description Seconds until authentication will have passed the session limit.
+             */
+            expires_in: number;
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    get_my_groups_and_memberships_v2_groups_my_groups_get: {
+        parameters: {
+            query?: {
+                /** @description Form-encoded or comma-separated list of statuses.  Memberships with these statuses will be included in the memberships array.  Valid values are `active`, `invited`, `pending`, `rejected`, `removed`, `left`, and `declined`. */
+                statuses?: string[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupReadModel"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_statuses_v2_groups_statuses_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A mapping from group_id to an object of status counts for memberships */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["GroupStatusCounts"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_group_v2_groups__group_id__get: {
+        parameters: {
+            query?: {
+                /** @description Form encoded or comma separated list of additional fields to include (allowed fields are `memberships`, `my_memberships`,`policies`, `allowed_actions`, and `child_ids` ) */
+                include?: string[] | null;
+            };
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupReadModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    update_group_v2_groups__group_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupWriteModel"];
+            };
+        };
+        responses: {
+            /** @description The updated group. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupReadModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    group_membership_post_actions_v2_groups__group_id__post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "community-context"?: string | null;
+            };
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupMembershipPostAction"];
+            };
+        };
+        responses: {
+            /** @description A list of the changed memberships and a list of errors that occurred */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupMembershipPostActionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestErrorModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    delete_group_v2_groups__group_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupReadModel"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestErrorModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_children_v2_groups__group_id__children_get: {
+        parameters: {
+            query?: {
+                /** @description Form encoded or comma separated list of additional fields to include (allowed fields are `memberships`, `my_memberships`,`policies`, `allowed_actions`, and `child_ids` ) */
+                include?: string[] | null;
+            };
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupChildrenReadModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    create_group_v2_groups_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupCreateModel"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupReadModel"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestErrorModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_policies_v2_groups__group_id__policies_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The current group policies. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupPolicyReadModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    update_policies_v2_groups__group_id__policies_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupPolicyWriteModel"];
+            };
+        };
+        responses: {
+            /** @description The updated set of policies. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupPolicyReadModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_identity_set_preferences_v2_preferences_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A mapping from identity_id to a list of preferences. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["IdentityPreferences"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    put_identity_set_preferences_v2_preferences_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: components["schemas"]["IdentityPreferences"];
+                };
+            };
+        };
+        responses: {
+            /** @description A mapping from identity_id to a list of preferences. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["IdentityPreferences"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_membership_fields_v2_groups__group_id__membership_fields_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A mapping from identity_id to an object of membership fields. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["MembershipFields"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    put_membership_fields_v2_groups__group_id__membership_fields_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: components["schemas"]["MembershipFields"];
+                };
+            };
+        };
+        responses: {
+            /** @description A mapping from identity_id to a list of membership fields. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["MembershipFields"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+    get_group_by_subscription_id_v2_subscription_info__subscription_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                subscription_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of groups with the given subscription_id. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupSubscriptionModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthErrorModel"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseErrorModel"];
+                };
+            };
+        };
+    };
+}

--- a/src/open-api/types/timer.d.ts
+++ b/src/open-api/types/timer.d.ts
@@ -1,0 +1,913 @@
+export interface paths {
+    "/jobs/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Jobs
+         * @description List the current user's timers.
+         *
+         *     By default, this includes all of the user's timers, even those which have ended.
+         */
+        get: operations["list_jobs_jobs__get"];
+        put?: never;
+        /**
+         * Submit Job
+         * @description Submit a new job (timer).
+         *
+         *     Some aspects to note for job submissions:
+         *     - Intervals are rounded down to the nearest second
+         *     - Jobs must be scheduled to start after 1970-01-01
+         *       and within one year of when it is submitted.
+         *     - If the job is set to stop after exactly 1 run then the interval must be null.
+         *       Otherwise, the job interval must be between 60 seconds and 365 days.
+         */
+        post: operations["submit_job_jobs__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Job
+         * @description Get the information for a specific job.
+         *
+         *     Because re-running the job over time can accumulate a large number of results, the
+         *     results are only available in individual pages. A "default" request to this URL
+         *     returns the first page within the `results` field, along with a `page_next` field
+         *     you pass as the query argument `results_pt` to obtain the next page.
+         */
+        get: operations["read_job_jobs__job_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Job
+         * @description Modify an existing job.
+         *
+         *     This can only be used to update a subset of fields.
+         */
+        patch: operations["update_job_jobs__job_id__patch"];
+        trace?: never;
+    };
+    "/jobs/{job_id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Job
+         * @description Pause a job.
+         *
+         *     This will set the job's status to inactive, preventing execution
+         *     until it is resumed.
+         */
+        post: operations["pause_job_jobs__job_id__pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{job_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Job
+         * @description Resume an inactive job.
+         *
+         *     This will set the job's status to 'active', allowing
+         *     execution on its schedule. If a run was missed, it will run once
+         *     immediately upon resuming.
+         *
+         *     If the `update_credentials` query parameter is set to `true`, the timer's
+         *     refresh token will be replaced with a new one.
+         */
+        post: operations["resume_job_jobs__job_id__resume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{timer_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Timer
+         * @description Remove a previously-submitted timer.
+         *
+         *     Timers are not deleted from the database, but are instead marked for deletion.
+         *     They are marked here as "delete_in_progress".
+         *
+         *     For transfer timers, results' action IDs must be deleted from the Transfer AP.
+         *     A background worker will do the cleanup work for both types of timers
+         *     to delete the results and mark the timers as "deleted".
+         */
+        delete: operations["delete_timer_jobs__timer_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/timer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Timer
+         * @description Create a new Timer.
+         *
+         *     If the job is set to stop after exactly 1 run then the interval must be null.
+         *     Otherwise, the job interval must be between 60 seconds and 365 days.
+         *
+         *     The timer must specify a type.
+         *     Currently, only the "transfer" type is supported.
+         */
+        post: operations["create_timer_v2_timer_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /**
+         * EndConditionIterations
+         * @description The condition for a timer which stops running after a number of calls.
+         */
+        EndConditionIterations: {
+            /**
+             * Condition
+             * @default iterations
+             * @enum {string}
+             */
+            condition: "iterations";
+            /** Count */
+            count: number;
+        };
+        /**
+         * EndConditionTime
+         * @description The end condition for a timer which stops running after a time.
+         */
+        EndConditionTime: {
+            /**
+             * Condition
+             * @default time
+             * @enum {string}
+             */
+            condition: "time";
+            /**
+             * Datetime
+             * Format: date-time
+             */
+            datetime: string;
+        };
+        /** FilterRule */
+        FilterRule: {
+            /**
+             * Data Type
+             * @default filter_rule
+             * @enum {string}
+             */
+            DATA_TYPE: "filter_rule";
+            /** Name */
+            name: string;
+            /**
+             * Method
+             * @default exclude
+             * @enum {string}
+             */
+            method: "include" | "exclude";
+            /**
+             * Type
+             * @enum {string}
+             */
+            type?: "file" | "dir";
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /** JobCreate */
+        JobCreate: {
+            /** Name */
+            name?: string;
+            stop_after?: components["schemas"]["StopAfter"];
+            /**
+             * Interval
+             * Format: time-delta
+             */
+            interval?: number;
+            /**
+             * Scope
+             * @example https://auth.globus.org/scopes/actions.globus.org/transfer/transfer
+             */
+            scope?: string;
+            /** Refresh Token */
+            refresh_token?: string;
+            /**
+             * Callback Url
+             * Format: uri
+             * @example [
+             *       "https://actions.automate.globus.org/transfer/transfer/run"
+             *     ]
+             */
+            callback_url: string;
+            /**
+             * Callback Body
+             * @example {
+             *       "request_id": "a403b459-376e-47a2-a55d-30e7ddbcc3d2",
+             *       "body": {
+             *         "source_endpoint_id": "just_an_example"
+             *       }
+             *     }
+             */
+            callback_body: Record<string, unknown>;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+        };
+        /** JobInactiveReason */
+        JobInactiveReason: {
+            /**
+             * Cause
+             * @enum {string}
+             */
+            cause: "user" | "globus_auth_requirements";
+            /** Detail */
+            detail?: Record<string, unknown>;
+        };
+        /** JobRead */
+        JobRead: {
+            /** Name */
+            name?: string;
+            stop_after?: components["schemas"]["StopAfter"];
+            /**
+             * Interval
+             * Format: time-delta
+             */
+            interval?: number;
+            /**
+             * Scope
+             * @example https://auth.globus.org/scopes/actions.globus.org/transfer/transfer
+             */
+            scope?: string;
+            /**
+             * Callback Url
+             * Format: uri
+             * @example [
+             *       "https://actions.automate.globus.org/transfer/transfer/run"
+             *     ]
+             */
+            callback_url: string;
+            /**
+             * Callback Body
+             * @example {
+             *       "request_id": "a403b459-376e-47a2-a55d-30e7ddbcc3d2",
+             *       "body": {
+             *         "source_endpoint_id": "just_an_example"
+             *       }
+             *     }
+             */
+            callback_body: Record<string, unknown>;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+            inactive_reason?: components["schemas"]["JobInactiveReason"];
+            /**
+             * Job Id
+             * Format: uuid
+             */
+            job_id: string;
+            /** Status */
+            status: string;
+            /**
+             * Submitted At
+             * Format: date-time
+             */
+            submitted_at: string;
+            /**
+             * Last Ran At
+             * Format: date-time
+             */
+            last_ran_at?: string;
+            /**
+             * Next Run
+             * Format: date-time
+             */
+            next_run?: string;
+            /** N Runs */
+            n_runs: number;
+            /** N Errors */
+            n_errors: number;
+            results: components["schemas"]["JobResultPage"];
+            /** Schedule */
+            schedule: components["schemas"]["OnceSchedule"] | components["schemas"]["RecurringSchedule"];
+        };
+        /** JobResult */
+        JobResult: {
+            /** Data */
+            data?: Record<string, unknown>;
+            /** Errors */
+            errors?: Record<string, unknown>;
+            /** Status */
+            status?: number;
+            /**
+             * Ran At
+             * Format: date-time
+             */
+            ran_at: string;
+        };
+        /** JobResultPage */
+        JobResultPage: {
+            /** Data */
+            data: components["schemas"]["JobResult"][];
+            /** Page Next */
+            page_next?: string;
+        };
+        /** JobResumeBehavior */
+        JobResumeBehavior: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "run_once_immediately" | "wait_for_next_scheduled";
+        };
+        /** JobUpdate */
+        JobUpdate: {
+            /** Name */
+            name?: string;
+        };
+        /** MessageResponse */
+        MessageResponse: {
+            /** Message */
+            message: string;
+        };
+        /**
+         * OnceSchedule
+         * @description The schedule for a timer which runs once at a specific time.
+         */
+        OnceSchedule: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "once";
+            /**
+             * When to run the timer
+             * Format: date-time
+             * @description The time at which the timer should run. This must be provided as a time in the future or close to the current time.
+             */
+            datetime?: string;
+        };
+        /**
+         * RecurringSchedule
+         * @description The schedule for a timer which repeats until an end condition is met,
+         *     or indefinitely if there is no end condition.
+         */
+        RecurringSchedule: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "recurring";
+            /**
+             * The interval on which the timer runs.
+             * @description The number of seconds between runs of the timer.
+             */
+            interval_seconds: number;
+            /**
+             * When to start the timer
+             * Format: date-time
+             * @description The time at which the timer should start running. This must be provided as a time in the future or close to the current time.
+             */
+            start?: string;
+            /** End */
+            end?: components["schemas"]["EndConditionTime"] | components["schemas"]["EndConditionIterations"];
+        };
+        /** StopAfter */
+        StopAfter: {
+            /**
+             * Date
+             * Format: date-time
+             */
+            date?: string;
+            /** N Runs */
+            n_runs?: number;
+        };
+        /** TransferTaskDocument */
+        TransferTaskDocument: {
+            /**
+             * Data Type
+             * @default transfer
+             * @enum {string}
+             */
+            DATA_TYPE: "transfer";
+            /** Source Endpoint */
+            source_endpoint: string;
+            /** Destination Endpoint */
+            destination_endpoint: string;
+            /** Data */
+            DATA: components["schemas"]["TransferTaskItem"][];
+            /** Deadline */
+            deadline?: string;
+            /**
+             * Delete Destination Extra
+             * @default false
+             */
+            delete_destination_extra: boolean;
+            /** Destination Local User */
+            destination_local_user?: string;
+            /**
+             * Encrypt Data
+             * @default false
+             */
+            encrypt_data: boolean;
+            /**
+             * Fail On Quota Errors
+             * @default false
+             */
+            fail_on_quota_errors: boolean;
+            /** Filter Rules */
+            filter_rules?: components["schemas"]["FilterRule"][];
+            /** Label */
+            label?: string;
+            /**
+             * Notify On Failed
+             * @default true
+             */
+            notify_on_failed: boolean;
+            /**
+             * Notify On Inactive
+             * @default true
+             */
+            notify_on_inactive: boolean;
+            /**
+             * Notify On Succeeded
+             * @default true
+             */
+            notify_on_succeeded: boolean;
+            /**
+             * Preserve Timestamp
+             * @default false
+             */
+            preserve_timestamp: boolean;
+            /**
+             * Skip Source Errors
+             * @default false
+             */
+            skip_source_errors: boolean;
+            /** Source Local User */
+            source_local_user?: string;
+            /**
+             * Store Base Path Info
+             * @default false
+             */
+            store_base_path_info: boolean;
+            /**
+             * Sync Level
+             * @enum {integer}
+             */
+            sync_level?: 0 | 1 | 2 | 3;
+            /**
+             * Verify Checksum
+             * @default false
+             */
+            verify_checksum: boolean;
+        };
+        /** TransferTaskItem */
+        TransferTaskItem: {
+            /**
+             * Data Type
+             * @default transfer_item
+             * @enum {string}
+             */
+            DATA_TYPE: "transfer_item";
+            /** Source Path */
+            source_path: string;
+            /** Destination Path */
+            destination_path: string;
+            /** Recursive */
+            recursive?: boolean;
+            /** External Checksum */
+            external_checksum?: string;
+            /** Checksum Algorithm */
+            checksum_algorithm?: string;
+        };
+        /** V2TimerCreate */
+        V2TimerCreate: {
+            timer: components["schemas"]["V2TransferTimerCreate"];
+        };
+        /** V2TimerRead */
+        V2TimerRead: {
+            timer: components["schemas"]["V2TransferTimerRead"];
+        };
+        /** V2TransferTimerCreate */
+        V2TransferTimerCreate: {
+            /** Name */
+            name?: string;
+            /** Schedule */
+            schedule: components["schemas"]["OnceSchedule"] | components["schemas"]["RecurringSchedule"];
+            /**
+             * Timer Type
+             * @enum {string}
+             */
+            timer_type: "transfer";
+            /**
+             * Resource Server
+             * @default transfer.api.globus.org
+             * @enum {string}
+             */
+            resource_server: "transfer.api.globus.org";
+            body: components["schemas"]["TransferTaskDocument"];
+        };
+        /** V2TransferTimerRead */
+        V2TransferTimerRead: {
+            /** Name */
+            name?: string;
+            /** Schedule */
+            schedule: components["schemas"]["OnceSchedule"] | components["schemas"]["RecurringSchedule"];
+            inactive_reason?: components["schemas"]["JobInactiveReason"];
+            /**
+             * Job Id
+             * Format: uuid
+             */
+            job_id: string;
+            /** Status */
+            status: string;
+            /**
+             * Submitted At
+             * Format: date-time
+             */
+            submitted_at: string;
+            /**
+             * Last Ran At
+             * Format: date-time
+             */
+            last_ran_at?: string;
+            /**
+             * Next Run
+             * Format: date-time
+             */
+            next_run?: string;
+            /** Number Of Runs */
+            number_of_runs: number;
+            /** Number Of Errors */
+            number_of_errors: number;
+            /**
+             * Timer Type
+             * @default transfer
+             * @enum {string}
+             */
+            timer_type: "transfer";
+            body: components["schemas"]["TransferTaskDocument"];
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    list_jobs_jobs__get: {
+        parameters: {
+            query?: {
+                /** @description List only jobs with names containing the argument as a substring
+                 *             (case-insensitive). */
+                filter_name?: string;
+                /** @description Filter listed jobs to only those submitted after the specified date. */
+                submitted_after?: string;
+                /** @description Filter listed jobs to only those submitted before the specified date. */
+                submitted_before?: string;
+                /** @description [DEPRECATED] Equivalent to 'filter_status=active'. */
+                filter_active?: boolean;
+                /** @description [DEPRECATED] Equivalent to 'filter_status=ended'. */
+                filter_stopped?: boolean;
+                /** @description Only return timers with the provided statuses, specified as a comma-separated
+                 *             list. Valid statuses are 'active', 'inactive', and 'ended'.
+                 *             Defaults to 'active,inactive,ended'. */
+                filter_status?: string;
+                /** @description Limit the number of results returned per job. */
+                result_count?: number;
+                /** @description Specify the order of the returned job list. The argument provided has the format
+                 *             `FIELD [asc|desc]` where `FIELD` is any orderable field on the job model. `asc`
+                 *             or `desc` is separated with a space from the field name. If neither is provided,
+                 *             the ordering always defaults to ascending. For example, `name desc` would list
+                 *             jobs in reverse alphabetical order on name; `submitted_at` (with no ordering
+                 *             specified) would list oldest jobs first. */
+                order?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        jobs?: components["schemas"]["JobRead"][];
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_job_jobs__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_job_jobs__job_id__get: {
+        parameters: {
+            query?: {
+                results_pt?: string;
+                page_size?: number;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_job_jobs__job_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_job_jobs__job_id__pause_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_job_jobs__job_id__resume_post: {
+        parameters: {
+            query?: {
+                update_credentials?: boolean;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_timer_jobs__timer_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                timer_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_timer_v2_timer_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V2TimerCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2TimerRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+}

--- a/src/services/compute/index.ts
+++ b/src/services/compute/index.ts
@@ -6,6 +6,8 @@
  */
 import * as COMPUTE from './config.js';
 
+export type * as OpenAPI from '../../open-api/types/compute';
+
 /**
  * @private
  * @internal

--- a/src/services/compute/service/endpoints.ts
+++ b/src/services/compute/service/endpoints.ts
@@ -1,4 +1,3 @@
-import type { operations } from '@globus/types/compute';
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 import { ID, SCOPES } from '../config.js';
 
@@ -8,12 +7,14 @@ import type {
   JSONFetchResponse,
 } from '../../types.js';
 
+import type { OpenAPI } from '../index.js';
+
 export const getAll = function (
   options?,
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_endpoints_v2_endpoints_get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_endpoints_v2_endpoints_get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -27,7 +28,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies ServiceMethod<{
-  query: operations['get_endpoints_v2_endpoints_get']['parameters']['query'];
+  query: OpenAPI.operations['get_endpoints_v2_endpoints_get']['parameters']['query'];
 }>;
 
 export const get = function (
@@ -36,7 +37,7 @@ export const get = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -50,7 +51,7 @@ export const get = function (
     sdkOptions,
   );
 } satisfies ServiceMethodDynamicSegments<
-  operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['parameters']['path']['endpoint_uuid'],
+  OpenAPI.operations['get_endpoint_v2_endpoints__endpoint_uuid__get']['parameters']['path']['endpoint_uuid'],
   {
     query?: never;
     payload?: never;
@@ -63,7 +64,7 @@ export const getStatus = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_endpoint_status_v2_endpoints__endpoint_uuid__status_get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_endpoint_status_v2_endpoints__endpoint_uuid__status_get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -76,7 +77,7 @@ export const getStatus = function (
     sdkOptions,
   );
 } satisfies ServiceMethodDynamicSegments<
-  operations['get_endpoint_status_v2_endpoints__endpoint_uuid__status_get']['parameters']['path']['endpoint_uuid'],
+  OpenAPI.operations['get_endpoint_status_v2_endpoints__endpoint_uuid__status_get']['parameters']['path']['endpoint_uuid'],
   {
     query?: never;
     payload?: never;

--- a/src/services/globus-connect-server/index.ts
+++ b/src/services/globus-connect-server/index.ts
@@ -13,6 +13,8 @@ import type {
   BaseServiceMethodOptions,
 } from '../types.js';
 
+export type * as OpenAPI from '../../open-api/types/gcs/v5.4';
+
 /**
  * Service methods for the Globus Connect Server Manager API.
  */

--- a/src/services/globus-connect-server/service/collections.ts
+++ b/src/services/globus-connect-server/service/collections.ts
@@ -1,7 +1,6 @@
-import type { operations } from '@globus/types/gcs-manager/api';
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
-import type { GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
+import type { OpenAPI, GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
 
 import type { JSONFetchResponse } from '../../types';
 
@@ -14,7 +13,7 @@ export const getAll = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['listCollections']['responses']['200']['content']['application/json']
+    OpenAPI.operations['listCollections']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -27,7 +26,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  query?: operations['listCollections']['parameters']['query'];
+  query?: OpenAPI.operations['listCollections']['parameters']['query'];
 }>;
 
 /**
@@ -39,7 +38,9 @@ export const get = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getCollection']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getCollection']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -51,9 +52,9 @@ export const get = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['getCollection']['parameters']['path']['collection_id'],
+  OpenAPI.operations['getCollection']['parameters']['path']['collection_id'],
   {
-    query?: operations['getCollection']['parameters']['query'];
+    query?: OpenAPI.operations['getCollection']['parameters']['query'];
   }
 >;
 
@@ -67,7 +68,7 @@ export const remove = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['deleteCollection']['responses']['200']['content']['application/json']
+    OpenAPI.operations['deleteCollection']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -81,7 +82,7 @@ export const remove = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteCollection']['parameters']['path']['collection_id'],
+  OpenAPI.operations['deleteCollection']['parameters']['path']['collection_id'],
   {
     query?: never;
     payload?: never;
@@ -96,7 +97,9 @@ export const create = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['postCollection']['responses']['201']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['postCollection']['responses']['201']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -109,7 +112,7 @@ export const create = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['postCollection']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['postCollection']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -121,7 +124,9 @@ export const update = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['putCollection']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['putCollection']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -134,9 +139,9 @@ export const update = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['putCollection']['parameters']['path']['collection_id'],
+  OpenAPI.operations['putCollection']['parameters']['path']['collection_id'],
   {
-    payload: operations['putCollection']['requestBody']['content']['application/json'];
+    payload: OpenAPI.operations['putCollection']['requestBody']['content']['application/json'];
   }
 >;
 
@@ -150,7 +155,7 @@ export const patch = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['patchCollection']['responses']['200']['content']['application/json']
+    OpenAPI.operations['patchCollection']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -164,9 +169,11 @@ export const patch = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['patchCollection']['parameters']['path']['collection_id'],
+  OpenAPI.operations['patchCollection']['parameters']['path']['collection_id'],
   {
-    payload: Partial<operations['patchCollection']['requestBody']['content']['application/json']>;
+    payload: Partial<
+      OpenAPI.operations['patchCollection']['requestBody']['content']['application/json']
+    >;
   }
 >;
 
@@ -180,7 +187,7 @@ export const updateOwnerString = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putCollectionOwnerString']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putCollectionOwnerString']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -194,10 +201,10 @@ export const updateOwnerString = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['putCollectionOwnerString']['parameters']['path']['collection_id'],
+  OpenAPI.operations['putCollectionOwnerString']['parameters']['path']['collection_id'],
   {
     payload: Partial<
-      operations['putCollectionOwnerString']['requestBody']['content']['application/json']
+      OpenAPI.operations['putCollectionOwnerString']['requestBody']['content']['application/json']
     >;
   }
 >;
@@ -212,7 +219,7 @@ export const resetOwnerString = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['deleteCollectionOwnerString']['responses']['200']['content']['application/json']
+    OpenAPI.operations['deleteCollectionOwnerString']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -226,6 +233,6 @@ export const resetOwnerString = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteCollectionOwnerString']['parameters']['path']['collection_id'],
+  OpenAPI.operations['deleteCollectionOwnerString']['parameters']['path']['collection_id'],
   {}
 >;

--- a/src/services/globus-connect-server/service/endpoint.ts
+++ b/src/services/globus-connect-server/service/endpoint.ts
@@ -1,7 +1,6 @@
-import type { operations } from '@globus/types/gcs-manager/api';
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
-import type { GCSServiceMethod } from '../index';
+import type { OpenAPI, GCSServiceMethod } from '../index';
 import type { JSONFetchResponse } from '../../types';
 
 /**
@@ -12,7 +11,9 @@ export const get = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getEndpoint']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getEndpoint']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -36,7 +37,9 @@ export const update = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['putEndpoint']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['putEndpoint']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -49,7 +52,7 @@ export const update = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['putEndpoint']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['putEndpoint']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -60,7 +63,9 @@ export const patch = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['patchEndpoint']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['patchEndpoint']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -80,7 +85,7 @@ export const patch = function (
    * when the auotgenerated types are corrected.
    */
   payload:
-    | operations['patchEndpoint']['requestBody']['content']['application/json']
+    | OpenAPI.operations['patchEndpoint']['requestBody']['content']['application/json']
     | Record<string, unknown>;
 }>;
 
@@ -93,7 +98,7 @@ export const updateSubscriptionId = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putEndpointSubscriptionId']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putEndpointSubscriptionId']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -107,7 +112,7 @@ export const updateSubscriptionId = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['putEndpointSubscriptionId']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['putEndpointSubscriptionId']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -119,7 +124,7 @@ export const updateOwner = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putEndpointOwner']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putEndpointOwner']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -133,7 +138,7 @@ export const updateOwner = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['putEndpointOwner']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['putEndpointOwner']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -145,7 +150,7 @@ export const updateOwnerString = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putEndpointOwnerString']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putEndpointOwnerString']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -159,7 +164,7 @@ export const updateOwnerString = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['putEndpointOwnerString']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['putEndpointOwnerString']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -171,7 +176,7 @@ export const resetOwnerString = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['deleteEndpointOwnerString']['responses']['200']['content']['application/json']
+    OpenAPI.operations['deleteEndpointOwnerString']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(

--- a/src/services/globus-connect-server/service/nodes.ts
+++ b/src/services/globus-connect-server/service/nodes.ts
@@ -1,8 +1,6 @@
-import type { operations } from '@globus/types/gcs-manager/api';
-
 import { HTTP_METHODS, serviceRequest } from '../../../services/shared.js';
 
-import type { GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
+import type { OpenAPI, GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
 
 import type { JSONFetchResponse } from '../../types';
 
@@ -14,7 +12,9 @@ export const getAll = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['listNodes']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['listNodes']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -26,7 +26,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  query?: operations['listNodes']['parameters']['query'];
+  query?: OpenAPI.operations['listNodes']['parameters']['query'];
 }>;
 
 /**
@@ -38,7 +38,9 @@ export const get = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getNode']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getNode']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -50,7 +52,7 @@ export const get = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['getNode']['parameters']['path']['node_id'],
+  OpenAPI.operations['getNode']['parameters']['path']['node_id'],
   {
     query?: never;
     payload?: never;
@@ -66,7 +68,9 @@ export const remove = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['deleteNode']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['deleteNode']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -79,7 +83,7 @@ export const remove = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteNode']['parameters']['path']['node_id'],
+  OpenAPI.operations['deleteNode']['parameters']['path']['node_id'],
   {
     query?: never;
     payload?: never;
@@ -94,7 +98,9 @@ export const create = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['postNode']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['postNode']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -107,7 +113,7 @@ export const create = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['postNode']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['postNode']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -119,7 +125,9 @@ export const update = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['putNode']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['putNode']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -132,9 +140,9 @@ export const update = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['putNode']['parameters']['path']['node_id'],
+  OpenAPI.operations['putNode']['parameters']['path']['node_id'],
   {
-    payload: operations['putNode']['requestBody']['content']['application/json'];
+    payload: OpenAPI.operations['putNode']['requestBody']['content']['application/json'];
   }
 >;
 
@@ -147,7 +155,9 @@ export const patch = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['patchNode']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['patchNode']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -160,8 +170,8 @@ export const patch = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['patchNode']['parameters']['path']['node_id'],
+  OpenAPI.operations['patchNode']['parameters']['path']['node_id'],
   {
-    payload: Partial<operations['patchNode']['requestBody']['content']['application/json']>;
+    payload: Partial<OpenAPI.operations['patchNode']['requestBody']['content']['application/json']>;
   }
 >;

--- a/src/services/globus-connect-server/service/roles.ts
+++ b/src/services/globus-connect-server/service/roles.ts
@@ -1,11 +1,8 @@
-import type { operations } from '@globus/types/gcs-manager/api';
-
 import { HTTP_METHODS, serviceRequest } from '../../../services/shared.js';
 
-import type { GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
+import type { OpenAPI, GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
 
 import type { JSONFetchResponse } from '../../types';
-
 /**
  * @see https://docs.globus.org/globus-connect-server/v5.4/api/openapi_Roles/#listRoles
  */
@@ -14,7 +11,9 @@ export const getAll = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['listRoles']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['listRoles']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -26,7 +25,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  query?: operations['listRoles']['parameters']['query'];
+  query?: OpenAPI.operations['listRoles']['parameters']['query'];
 }>;
 
 /**
@@ -38,7 +37,9 @@ export const get = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getRole']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getRole']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -50,7 +51,7 @@ export const get = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['getRole']['parameters']['path']['role_id'],
+  OpenAPI.operations['getRole']['parameters']['path']['role_id'],
   {
     query?: never;
     payload?: never;
@@ -66,7 +67,9 @@ export const remove = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['deleteRole']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['deleteRole']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -79,7 +82,7 @@ export const remove = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteRole']['parameters']['path']['role_id'],
+  OpenAPI.operations['deleteRole']['parameters']['path']['role_id'],
   {
     query?: never;
     payload?: never;
@@ -94,7 +97,9 @@ export const create = function (
   options,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['postRoles']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['postRoles']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -107,5 +112,5 @@ export const create = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['postRoles']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['postRoles']['requestBody']['content']['application/json'];
 }>;

--- a/src/services/globus-connect-server/service/storage-gateways.ts
+++ b/src/services/globus-connect-server/service/storage-gateways.ts
@@ -1,10 +1,8 @@
-import type { operations } from '@globus/types/gcs-manager/api';
 import { HTTP_METHODS, serviceRequest } from '../../../services/shared.js';
 
-import type { GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
+import type { OpenAPI, GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
 
 import type { JSONFetchResponse } from '../../types';
-
 /**
  * @see https://docs.globus.org/globus-connect-server/v5.4/api/openapi_Storage_Gateways/#listStorageGateways
  */
@@ -14,7 +12,7 @@ export const getAll = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['listStorageGateways']['responses']['200']['content']['application/json']
+    OpenAPI.operations['listStorageGateways']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -27,7 +25,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  query?: operations['listStorageGateways']['parameters']['query'];
+  query?: OpenAPI.operations['listStorageGateways']['parameters']['query'];
 }>;
 
 /**
@@ -40,7 +38,7 @@ export const get = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['getStorageGateway']['responses']['200']['content']['application/json']
+    OpenAPI.operations['getStorageGateway']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -53,9 +51,9 @@ export const get = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['getStorageGateway']['parameters']['path']['storage_gateway_id'],
+  OpenAPI.operations['getStorageGateway']['parameters']['path']['storage_gateway_id'],
   {
-    query?: operations['getStorageGateway']['parameters']['query'];
+    query?: OpenAPI.operations['getStorageGateway']['parameters']['query'];
   }
 >;
 
@@ -69,7 +67,7 @@ export const remove = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['deleteStorageGateway']['responses']['200']['content']['application/json']
+    OpenAPI.operations['deleteStorageGateway']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -83,7 +81,7 @@ export const remove = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteStorageGateway']['parameters']['path']['storage_gateway_id'],
+  OpenAPI.operations['deleteStorageGateway']['parameters']['path']['storage_gateway_id'],
   {
     query?: never;
     payload?: never;
@@ -99,7 +97,7 @@ export const create = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['postStorageGateway']['responses']['201']['content']['application/json']
+    OpenAPI.operations['postStorageGateway']['responses']['201']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -113,7 +111,7 @@ export const create = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['postStorageGateway']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['postStorageGateway']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -126,7 +124,7 @@ export const update = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putStorageGateway']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putStorageGateway']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -140,9 +138,9 @@ export const update = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['putStorageGateway']['parameters']['path']['storage_gateway_id'],
+  OpenAPI.operations['putStorageGateway']['parameters']['path']['storage_gateway_id'],
   {
-    payload: operations['putStorageGateway']['requestBody']['content']['application/json'];
+    payload: OpenAPI.operations['putStorageGateway']['requestBody']['content']['application/json'];
   }
 >;
 
@@ -156,7 +154,7 @@ export const patch = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['patchStorageGateway']['responses']['200']['content']['application/json']
+    OpenAPI.operations['patchStorageGateway']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -170,10 +168,10 @@ export const patch = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['patchStorageGateway']['parameters']['path']['storage_gateway_id'],
+  OpenAPI.operations['patchStorageGateway']['parameters']['path']['storage_gateway_id'],
   {
     payload: Partial<
-      operations['patchStorageGateway']['requestBody']['content']['application/json']
+      OpenAPI.operations['patchStorageGateway']['requestBody']['content']['application/json']
     >;
   }
 >;

--- a/src/services/globus-connect-server/service/user-credentials.ts
+++ b/src/services/globus-connect-server/service/user-credentials.ts
@@ -1,10 +1,8 @@
-import type { operations } from '@globus/types/gcs-manager/api';
 import { HTTP_METHODS, serviceRequest } from '../../../services/shared.js';
 
-import type { GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
+import type { OpenAPI, GCSServiceMethod, GCSServiceMethodDynamicSegments } from '../index';
 
 import type { JSONFetchResponse } from '../../types';
-
 /**
  * @see https://docs.globus.org/globus-connect-server/v5.4/api/openapi_User_Credentials/#listUserCredentials
  */
@@ -14,7 +12,7 @@ export const getAll = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['listUserCredentials']['responses']['200']['content']['application/json']
+    OpenAPI.operations['listUserCredentials']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -27,7 +25,7 @@ export const getAll = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  query?: operations['listUserCredentials']['parameters']['query'];
+  query?: OpenAPI.operations['listUserCredentials']['parameters']['query'];
 }>;
 
 /**
@@ -39,7 +37,9 @@ export const get = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getCollection']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getCollection']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {
@@ -51,7 +51,7 @@ export const get = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['getUserCredential']['parameters']['path']['user_credential_id'],
+  OpenAPI.operations['getUserCredential']['parameters']['path']['user_credential_id'],
   {
     query?: never;
     payload?: never;
@@ -68,7 +68,7 @@ export const remove = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['deleteUserCredential']['responses']['200']['content']['application/json']
+    OpenAPI.operations['deleteUserCredential']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -82,7 +82,7 @@ export const remove = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['deleteUserCredential']['parameters']['path']['user_credential_id'],
+  OpenAPI.operations['deleteUserCredential']['parameters']['path']['user_credential_id'],
   {
     query?: never;
     payload?: never;
@@ -98,7 +98,7 @@ export const create = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['postUserCredential']['responses']['201']['content']['application/json']
+    OpenAPI.operations['postUserCredential']['responses']['201']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -112,7 +112,7 @@ export const create = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethod<{
-  payload: operations['postUserCredential']['requestBody']['content']['application/json'];
+  payload: OpenAPI.operations['postUserCredential']['requestBody']['content']['application/json'];
 }>;
 
 /**
@@ -125,7 +125,7 @@ export const update = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['putUserCredential']['responses']['200']['content']['application/json']
+    OpenAPI.operations['putUserCredential']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -139,9 +139,9 @@ export const update = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['putUserCredential']['parameters']['path']['user_credential_id'],
+  OpenAPI.operations['putUserCredential']['parameters']['path']['user_credential_id'],
   {
-    payload: operations['putUserCredential']['requestBody']['content']['application/json'];
+    payload: OpenAPI.operations['putUserCredential']['requestBody']['content']['application/json'];
   }
 >;
 
@@ -155,7 +155,7 @@ export const patch = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['patchUserCredential']['responses']['200']['content']['application/json']
+    OpenAPI.operations['patchUserCredential']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -169,10 +169,10 @@ export const patch = function (
     sdkOptions,
   );
 } satisfies GCSServiceMethodDynamicSegments<
-  operations['patchUserCredential']['parameters']['path']['user_credential_id'],
+  OpenAPI.operations['patchUserCredential']['parameters']['path']['user_credential_id'],
   {
     payload: Partial<
-      operations['patchUserCredential']['requestBody']['content']['application/json']
+      OpenAPI.operations['patchUserCredential']['requestBody']['content']['application/json']
     >;
   }
 >;

--- a/src/services/globus-connect-server/service/versioning.ts
+++ b/src/services/globus-connect-server/service/versioning.ts
@@ -1,7 +1,6 @@
-import type { operations } from '@globus/types/gcs-manager/api';
 import { serviceRequest } from '../../../services/shared.js';
 
-import type { GCSServiceMethod } from '../index';
+import type { OpenAPI, GCSServiceMethod } from '../index';
 import type { JSONFetchResponse } from '../../types';
 
 /**
@@ -13,7 +12,9 @@ export const info = function (
   options?,
   sdkOptions?,
 ): Promise<
-  JSONFetchResponse<operations['getInfo']['responses']['200']['content']['application/json']>
+  JSONFetchResponse<
+    OpenAPI.operations['getInfo']['responses']['200']['content']['application/json']
+  >
 > {
   return serviceRequest(
     {

--- a/src/services/groups/index.ts
+++ b/src/services/groups/index.ts
@@ -7,6 +7,8 @@
 
 import * as GROUPS from './config.js';
 
+export type * as OpenAPI from '../../open-api/types/groups';
+
 /**
  * @private
  * @internal

--- a/src/services/groups/service/groups.ts
+++ b/src/services/groups/service/groups.ts
@@ -1,6 +1,7 @@
-import type { operations, components } from '@globus/types/groups';
 import { ID, SCOPES } from '../config.js';
 import { serviceRequest } from '../../shared.js';
+
+import type { OpenAPI } from '../index.js';
 
 import type {
   JSONFetchResponse,
@@ -16,7 +17,7 @@ export const getMyGroups = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_my_groups_and_memberships_v2_groups_my_groups_get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_my_groups_and_memberships_v2_groups_my_groups_get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -33,7 +34,7 @@ export const getMyGroups = function (
     /**
      * @todo This should probably be replaced with a more specific type for the method's accepted query parameters once available.
      */
-    statuses?: components['schemas']['StatusEnum'][];
+    statuses?: OpenAPI.components['schemas']['StatusEnum'][];
   };
 }>;
 
@@ -46,7 +47,7 @@ export const get = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_group_v2_groups__group_id__get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_group_v2_groups__group_id__get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -59,8 +60,8 @@ export const get = function (
     sdkOptions,
   );
 } satisfies ServiceMethodDynamicSegments<
-  operations['get_group_v2_groups__group_id__get']['parameters']['path']['group_id'],
+  OpenAPI.operations['get_group_v2_groups__group_id__get']['parameters']['path']['group_id'],
   {
-    query?: operations['get_group_v2_groups__group_id__get']['parameters']['query'];
+    query?: OpenAPI.operations['get_group_v2_groups__group_id__get']['parameters']['query'];
   }
 >;

--- a/src/services/groups/service/membership.ts
+++ b/src/services/groups/service/membership.ts
@@ -1,7 +1,7 @@
-import type { operations } from '@globus/types/groups';
 import { ID, SCOPES } from '../config.js';
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 
+import type { OpenAPI } from '../index.js';
 import type { JSONFetchResponse, ServiceMethodDynamicSegments } from '../../types.js';
 
 /**
@@ -14,7 +14,7 @@ export const act = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['group_membership_post_actions_v2_groups__group_id__post']['responses']['200']['content']['application/json']
+    OpenAPI.operations['group_membership_post_actions_v2_groups__group_id__post']['responses']['200']['content']['application/json']
   >
 > {
   if (!options?.payload) throw new Error('payload is required.');
@@ -29,8 +29,8 @@ export const act = function (
     sdkOptions,
   );
 } satisfies ServiceMethodDynamicSegments<
-  operations['update_group_v2_groups__group_id__put']['parameters']['path']['group_id'],
+  OpenAPI.operations['update_group_v2_groups__group_id__put']['parameters']['path']['group_id'],
   {
-    payload: operations['group_membership_post_actions_v2_groups__group_id__post']['requestBody']['content']['application/json'];
+    payload: OpenAPI.operations['group_membership_post_actions_v2_groups__group_id__post']['requestBody']['content']['application/json'];
   }
 >;

--- a/src/services/groups/service/policies.ts
+++ b/src/services/groups/service/policies.ts
@@ -1,7 +1,7 @@
-import type { operations } from '@globus/types/groups';
 import { ID, SCOPES } from '../config.js';
 import { serviceRequest } from '../../shared.js';
 
+import type { OpenAPI } from '../index.js';
 import type { JSONFetchResponse, ServiceMethodDynamicSegments } from '../../types.js';
 
 /**
@@ -13,7 +13,7 @@ export const get = function (
   sdkOptions?,
 ): Promise<
   JSONFetchResponse<
-    operations['get_policies_v2_groups__group_id__policies_get']['responses']['200']['content']['application/json']
+    OpenAPI.operations['get_policies_v2_groups__group_id__policies_get']['responses']['200']['content']['application/json']
   >
 > {
   return serviceRequest(
@@ -26,7 +26,7 @@ export const get = function (
     sdkOptions,
   );
 } satisfies ServiceMethodDynamicSegments<
-  operations['get_policies_v2_groups__group_id__policies_get']['parameters']['path']['group_id'],
+  OpenAPI.operations['get_policies_v2_groups__group_id__policies_get']['parameters']['path']['group_id'],
   {
     query?: never;
     payload?: never;

--- a/src/services/timer/index.ts
+++ b/src/services/timer/index.ts
@@ -8,6 +8,8 @@ import * as TIMER from './config.js';
 
 import { create } from './service/timer.js';
 
+export type * as OpenAPI from '../../open-api/types/timer';
+
 /**
  * @private
  * @internal

--- a/src/services/timer/service/timer.ts
+++ b/src/services/timer/service/timer.ts
@@ -1,7 +1,7 @@
-import type { components } from '@globus/types/timer';
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 import { ID } from '../config.js';
 
+import type { OpenAPI } from '../index.js';
 import type { SDKOptions, ServiceMethod } from '../../types.js';
 
 export const create = function (options, sdkOptions?: SDKOptions) {
@@ -16,5 +16,5 @@ export const create = function (options, sdkOptions?: SDKOptions) {
     sdkOptions,
   );
 } satisfies ServiceMethod<{
-  payload: components['schemas']['V2TimerCreate'];
+  payload: OpenAPI.components['schemas']['V2TimerCreate'];
 }>;


### PR DESCRIPTION
- All services that have OpenAPI specs now export an `type OpenAPI` from their entrypoints.
- Adds script for generating types from the OpenAPI resources.