### PR TITLE
feat(Authorization): adds experimental `PopupTransport` for AuthorizationManager

### DIFF
--- a/src/core/__tests__/authorization/RedirectTransport.spec.ts
+++ b/src/core/__tests__/authorization/RedirectTransport.spec.ts
@@ -2,8 +2,9 @@ import { version } from 'node:process';
 
 import { mockSessionStorage } from '../../../__mocks__/sessionStorage';
 import '../../../__mocks__/window-location';
-import { KEYS, RedirectTransport } from '../../authorization/RedirectTransport';
+import { RedirectTransport } from '../../authorization/RedirectTransport';
 import { oauth2 } from '../../../services/auth';
+import { store } from '../../authorization/pkce';
 
 const MOCK_CONFIG = {
   client: 'CLIENT_ID',
@@ -65,7 +66,7 @@ describe('RedirectTransport', () => {
       /**
        * Ensure that the state is stored in sessionStorage.
        */
-      expect(sessionStorage.getItem(KEYS.PKCE_STATE)).toBe('CUSTOM_STATE');
+      expect(store.get('state')).toBe('CUSTOM_STATE');
     });
 
     describe('getToken', () => {
@@ -93,7 +94,7 @@ describe('RedirectTransport', () => {
       });
 
       it('throws on "state" mismatch', async () => {
-        sessionStorage.setItem(KEYS.PKCE_STATE, 'ACTUAL_STATE');
+        store.set('state', 'ACTUAL_STATE');
         window.location.href = `${MOCK_CONFIG.redirect}?code=CODE&state=INVALID_STATE`;
         const transport = new RedirectTransport(MOCK_CONFIG);
         await expect(async () => {
@@ -102,7 +103,7 @@ describe('RedirectTransport', () => {
       });
 
       it('throws on missing verifier', async () => {
-        sessionStorage.setItem(KEYS.PKCE_STATE, 'ACTUAL_STATE');
+        store.set('state', 'ACTUAL_STATE');
         window.location.href = `${MOCK_CONFIG.redirect}?code=CODE&state=ACTUAL_STATE`;
         const transport = new RedirectTransport(MOCK_CONFIG);
         await expect(async () => {
@@ -119,8 +120,8 @@ describe('RedirectTransport', () => {
          * Set fake state to be used as part of the OAuth flow.
          */
         const state = 'SOME_STATE';
-        sessionStorage.setItem(KEYS.PKCE_STATE, state);
-        sessionStorage.setItem(KEYS.PKCE_CODE_VERIFIER, 'CODE_VERIFIER');
+        store.set('state', state);
+        store.set('code_verifier', 'CODE_VERIFIER');
 
         const transport = new RedirectTransport(MOCK_CONFIG);
 
@@ -140,8 +141,8 @@ describe('RedirectTransport', () => {
          * Set fake state to be used as part of the OAuth flow.
          */
         const state = 'SOME_STATE';
-        sessionStorage.setItem(KEYS.PKCE_STATE, state);
-        sessionStorage.setItem(KEYS.PKCE_CODE_VERIFIER, 'CODE_VERIFIER');
+        store.set('state', state);
+        store.set('code_verifier', 'CODE_VERIFIER');
 
         const url = `${MOCK_CONFIG.redirect}?code=CODE&state=${state}`;
         const transport = new RedirectTransport(MOCK_CONFIG);

--- a/src/core/authorization/AuthorizationManager.ts
+++ b/src/core/authorization/AuthorizationManager.ts
@@ -28,11 +28,11 @@ import type {
   TokenWithRefresh,
 } from '../../services/auth/types.js';
 import { MemoryStorage } from '../storage/memory.js';
-// import { PopupTransport } from './PopupTransport.js';
+import { PopupTransport } from './PopupTransport.js';
 
 const TRANSPORTS = {
   redirect: RedirectTransport,
-  // popup: PopupTransport,
+  popup: PopupTransport,
 };
 
 export type AuthorizationManagerConfiguration = {
@@ -117,7 +117,7 @@ const DEFAULT_HANDLE_ERROR_OPTIONS = {
  * });
  */
 export class AuthorizationManager {
-  #transport!: RedirectTransport;
+  #transport!: RedirectTransport | PopupTransport;
 
   configuration: AuthorizationManagerConfiguration;
 
@@ -386,7 +386,11 @@ export class AuthorizationManager {
      * In the future, it's possible that we may want to support different types of transports.
      */
     const transport = this.#buildTransport({ params: options?.additionalParams });
-    await transport.send();
+    const result = await transport.send();
+    if (isGlobusAuthTokenResponse(result)) {
+      this.addTokenResponse(result);
+    }
+    return result;
   }
 
   /**
@@ -395,7 +399,11 @@ export class AuthorizationManager {
   async prompt(options?: Partial<RedirectTransportOptions>) {
     log('debug', 'AuthorizationManager.prompt');
     const transport = this.#buildTransport(options);
-    await transport.send();
+    const result = await transport.send();
+    if (isGlobusAuthTokenResponse(result)) {
+      this.addTokenResponse(result);
+    }
+    return result;
   }
 
   /**

--- a/src/core/authorization/PopupTransport.ts
+++ b/src/core/authorization/PopupTransport.ts
@@ -35,7 +35,8 @@ export class PopupTransport {
     }
   }
 
-  static supported = isSupported() && window && window.open;
+  static supported =
+    isSupported() && 'window' in globalThis && typeof globalThis.window.open === 'function';
 
   /**
    * For the redirect transport, sending the request will redirect the user to the authorization endpoint, initiating the OAuth flow.

--- a/src/core/authorization/PopupTransport.ts
+++ b/src/core/authorization/PopupTransport.ts
@@ -9,20 +9,21 @@ import {
   store,
 } from './pkce.js';
 
-import type { RedirectTransportOptions } from './RedirectTransport.js';
+import type { TransportOptions } from './RedirectTransport.js';
 
-export type GetTokenOptions = {
-  /**
-   * Whether or not the URL should be replaced after processing the token.
-   * @default true
-   */
-  shouldReplace?: boolean;
-};
-
-export type PopupTransportOptions = RedirectTransportOptions;
+export type PopupTransportOptions = TransportOptions;
 
 const MESSAGE_SOURCE = 'globus-sdk';
 
+/**
+ * The `PopupTransport` (`popup`) uses a popup window to initiate the OAuth 2.0 using PKCE.
+ *
+ * When using the `PopupTransport`, the `redirect` parameter should be to a location
+ * that will transmit the URL back to the opener. This can be done using `AuthorizationManager.handleCodeRedirect()`, or
+ * manually by calling `window.opener.postMessage()`.
+ *
+ * @experimental
+ */
 export class PopupTransport {
   #options: PopupTransportOptions;
 
@@ -35,6 +36,9 @@ export class PopupTransport {
     }
   }
 
+  /**
+   * The `PopupTransport` is supported in environments where the `window` object is available.
+   */
   static supported =
     isSupported() && 'window' in globalThis && typeof globalThis.window.open === 'function';
 

--- a/src/core/authorization/PopupTransport.ts
+++ b/src/core/authorization/PopupTransport.ts
@@ -1,0 +1,191 @@
+import { getAuthorizationEndpoint, oauth2 } from '../../services/auth/index.js';
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+  AuthorizationRequestParameters,
+  AuthorizationCodeExchangeParameters,
+  isSupported,
+} from './pkce.js';
+
+import type { RedirectTransportOptions } from './RedirectTransport.js';
+
+export type GetTokenOptions = {
+  /**
+   * Whether or not the URL should be replaced after processing the token.
+   * @default true
+   */
+  shouldReplace?: boolean;
+};
+
+export type PopupTransportOptions = RedirectTransportOptions;
+
+const MESSAGE_SOURCE = 'globus-sdk';
+
+/**
+ * @private
+ */
+export const KEYS = {
+  PKCE_STATE: 'pkce_state',
+  PKCE_CODE_VERIFIER: 'pkce_code_verifier',
+};
+
+function resetPKCE() {
+  sessionStorage.removeItem(KEYS.PKCE_STATE);
+  sessionStorage.removeItem(KEYS.PKCE_CODE_VERIFIER);
+}
+
+export class PopupTransport {
+  #options: PopupTransportOptions;
+
+  #window: Window | null = null;
+
+  constructor(options: PopupTransportOptions) {
+    this.#options = options;
+    if (PopupTransport.supported === false) {
+      throw new Error('PopupTransport is not supported in this environment.');
+    }
+  }
+
+  static supported = isSupported() && window && window.open;
+
+  /**
+   * For the redirect transport, sending the request will redirect the user to the authorization endpoint, initiating the OAuth flow.
+   */
+  async send() {
+    /**
+     * Since we'll be using PKCE, we need to generate a code verifier and challenge
+     * for the OAuth handshake.
+     */
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    /**
+     * If there is caller-provided `state`, use it; Otherwise, generate a state parameter.
+     */
+    const state = this.#options.params?.['state'] ?? generateState();
+    /**
+     * The verifier and state are stored in session storage so that we can validate
+     * the response when we receive it.
+     */
+    sessionStorage.setItem(KEYS.PKCE_CODE_VERIFIER, verifier);
+    sessionStorage.setItem(KEYS.PKCE_STATE, state);
+
+    const params: AuthorizationRequestParameters = {
+      response_type: 'code',
+      client_id: this.#options.client,
+      scope: this.#options.scopes || '',
+      redirect_uri: this.#options.redirect,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      ...(this.#options.params || {}),
+    };
+
+    const url = new URL(getAuthorizationEndpoint());
+    url.search = new URLSearchParams(params).toString();
+
+    const promise = new Promise((resolve) => {
+      window.addEventListener(
+        'message',
+        async (e) => {
+          const { data } = e;
+          if (e.origin !== window.location.origin || data?.source !== MESSAGE_SOURCE) {
+            return;
+          }
+          this.#window?.close();
+          const response = await this.#getToken(data.url);
+          resolve(response);
+        },
+        false,
+      );
+    });
+
+    this.#window = window.open(url.toString(), '_blank', 'width=800,height=600');
+
+    if (!this.#window) {
+      throw new Error('Unable to open window for PopupTransport.');
+    }
+
+    this.#window.focus();
+    return promise;
+  }
+
+  async #getToken(href: string) {
+    const url = new URL(href);
+    const params = new URLSearchParams(url.search);
+    /**
+     * Check for an error in the OAuth flow.
+     * @see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+     */
+    if (params.get('error')) {
+      throw new Error(
+        params.get('error_description') || 'An error occurred during the authorization process.',
+      );
+    }
+
+    const code = params.get('code');
+
+    /**
+     * If we don't have a `code` parameter, we can't exchange it for an access token.
+     */
+    if (!code) return undefined;
+
+    /**
+     * Grab the PKCE information from session storage.
+     */
+    const state = sessionStorage.getItem(KEYS.PKCE_STATE);
+    const verifier = sessionStorage.getItem(KEYS.PKCE_CODE_VERIFIER);
+    /**
+     * Now that we have the values in memory, we can remove them from session storage.
+     */
+    resetPKCE();
+
+    /**
+     * Validate the `state` parameter matches the preserved state (to prevent CSRF attacks).
+     */
+    if (params.get('state') !== state) {
+      throw new Error(
+        'Invalid State. The received "state" parameter does not match the expected state.',
+      );
+    }
+    /**
+     * Ensure we have a valid code verifier.
+     */
+    if (!verifier) {
+      throw new Error('Invalid Code Verifier');
+    }
+    /**
+     * Prepare the payload for the PKCE token exchange.
+     */
+    const payload: AuthorizationCodeExchangeParameters = {
+      code,
+      client_id: this.#options.client,
+      /**
+       * Retrieve the code verifier from session storage.
+       */
+      code_verifier: verifier,
+      redirect_uri: this.#options.redirect,
+      grant_type: 'authorization_code',
+    };
+    const response = await (
+      await oauth2.token.exchange({
+        payload,
+      })
+    ).json();
+    return response;
+  }
+
+  static getToken() {
+    if (!window.opener) {
+      return;
+    }
+
+    window.opener.postMessage(
+      {
+        source: MESSAGE_SOURCE,
+        url: window.location.href,
+      },
+      window.location.origin,
+    );
+  }
+}

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -27,20 +27,22 @@ export type GetTokenOptions = {
   includeConsentedScopes?: boolean;
 };
 
-export type RedirectTransportOptions = Pick<
+export type TransportOptions = Pick<
   AuthorizationManagerConfiguration,
   'client' | 'redirect' | 'scopes'
 > & {
   /**
    * Query parameters to include in the authorization request.
    *
-   * The `RedirectTransport` will include all parameters required for a default OAuth PKCE flow, but
+   * The transport will include all parameters required for a default OAuth PKCE flow, but
    * these parameters can be overridden or extended with this option.
    */
   params?: {
     [key: string]: string;
   };
 };
+
+export type RedirectTransportOptions = TransportOptions;
 export class RedirectTransport {
   #options: RedirectTransportOptions;
 

--- a/src/core/authorization/RedirectTransport.ts
+++ b/src/core/authorization/RedirectTransport.ts
@@ -6,6 +6,7 @@ import {
   AuthorizationRequestParameters,
   AuthorizationCodeExchangeParameters,
   isSupported,
+  store,
 } from './pkce.js';
 
 import type { AuthorizationManagerConfiguration } from './AuthorizationManager.js';
@@ -40,20 +41,6 @@ export type RedirectTransportOptions = Pick<
     [key: string]: string;
   };
 };
-
-/**
- * @private
- */
-export const KEYS = {
-  PKCE_STATE: 'pkce_state',
-  PKCE_CODE_VERIFIER: 'pkce_code_verifier',
-};
-
-function resetPKCE() {
-  sessionStorage.removeItem(KEYS.PKCE_STATE);
-  sessionStorage.removeItem(KEYS.PKCE_CODE_VERIFIER);
-}
-
 export class RedirectTransport {
   #options: RedirectTransportOptions;
 
@@ -84,8 +71,8 @@ export class RedirectTransport {
      * The verifier and state are stored in session storage so that we can validate
      * the response when we receive it.
      */
-    sessionStorage.setItem(KEYS.PKCE_CODE_VERIFIER, verifier);
-    sessionStorage.setItem(KEYS.PKCE_STATE, state);
+    store.set('code_verifier', verifier);
+    store.set('state', state);
 
     const params: AuthorizationRequestParameters = {
       response_type: 'code',
@@ -133,12 +120,12 @@ export class RedirectTransport {
     /**
      * Grab the PKCE information from session storage.
      */
-    const state = sessionStorage.getItem(KEYS.PKCE_STATE);
-    const verifier = sessionStorage.getItem(KEYS.PKCE_CODE_VERIFIER);
+    const state = store.get('state');
+    const verifier = store.get('code_verifier');
     /**
      * Now that we have the values in memory, we can remove them from session storage.
      */
-    resetPKCE();
+    store.reset();
 
     /**
      * Validate the `state` parameter matches the preserved state (to prevent CSRF attacks).

--- a/src/core/authorization/pkce.ts
+++ b/src/core/authorization/pkce.ts
@@ -82,3 +82,25 @@ export type AuthorizationRequestParameters = {
   code_challenge: string;
   code_challenge_method: 'S256' | 'plain';
 };
+
+/**
+ * @private
+ */
+export const KEYS = {
+  PKCE_STATE: 'pkce_state',
+  PKCE_CODE_VERIFIER: 'pkce_code_verifier',
+};
+
+type Entries = 'state' | 'code_verifier';
+
+export const store = {
+  getKey(key: Entries) {
+    return key === 'state' ? KEYS.PKCE_STATE : KEYS.PKCE_CODE_VERIFIER;
+  },
+  get: (entry: Entries) => sessionStorage.getItem(store.getKey(entry)),
+  set: (entry: Entries, value: string) => sessionStorage.setItem(store.getKey(entry), value),
+  reset: () => {
+    sessionStorage.removeItem(KEYS.PKCE_STATE);
+    sessionStorage.removeItem(KEYS.PKCE_CODE_VERIFIER);
+  },
+};


### PR DESCRIPTION
This pull request introduces a new transport for the `AuthorizationManager` – the `PopTransport`.

This transport is intended to facilitate using `@globus/sdk` as an authorization mechanism when a redirect is not possible (e.g. when inside of an `<iframe>`).

`<MORE DOCUMENTATION TO FOLLOW>`

---


Attached is an example of the usage in an experimental Storybook.

https://github.com/user-attachments/assets/32680ef7-ef0e-43b4-a9aa-e973be94adc4



