### PR TITLE
feat: Adds `request` method for making generic service requests using similar signatures and authorization integration.

### DIFF
--- a/src/__tests__/request.spec.ts
+++ b/src/__tests__/request.spec.ts
@@ -1,0 +1,110 @@
+import { request } from '../index';
+import { mirror } from '../__mocks__/handlers';
+
+describe('request', () => {
+  it('should be defined', () => {
+    expect(request).toBeDefined();
+  });
+
+  it('should be a function', () => {
+    expect(typeof request).toBe('function');
+  });
+
+  it('supports making requests to arbitrary service resources', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(
+      await request({
+        service: 'COMPUTE',
+        path: '/some-resource',
+      }),
+    );
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchInlineSnapshot(`
+          {
+            "headers": {
+              "accept": "*/*",
+              "accept-encoding": "gzip,deflate",
+              "connection": "close",
+              "host": "compute.api.globus.org",
+              "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+            },
+            "method": "GET",
+            "url": "https://compute.api.globus.org/some-resource",
+          }
+        `);
+  });
+
+  it('supports query parameters', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(
+      await request(
+        {
+          service: 'COMPUTE',
+          path: '/some-resource',
+        },
+        {
+          query: { foo: 'bar' },
+        },
+      ),
+    );
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchInlineSnapshot(`
+          {
+            "headers": {
+              "accept": "*/*",
+              "accept-encoding": "gzip,deflate",
+              "connection": "close",
+              "host": "compute.api.globus.org",
+              "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+            },
+            "method": "GET",
+            "url": "https://compute.api.globus.org/some-resource?foo=bar",
+          }
+        `);
+  });
+
+  it('supports headers', async () => {
+    const {
+      req: { url, method, headers },
+    } = await mirror(
+      await request(
+        {
+          service: 'COMPUTE',
+          path: '/some-resource',
+        },
+        {
+          query: { foo: 'bar' },
+          headers: {
+            Authorization: 'Bearer MY_ACCESS',
+          },
+        },
+      ),
+    );
+    expect({
+      url,
+      method,
+      headers,
+    }).toMatchInlineSnapshot(`
+          {
+            "headers": {
+              "accept": "*/*",
+              "accept-encoding": "gzip,deflate",
+              "authorization": "Bearer MY_ACCESS",
+              "connection": "close",
+              "host": "compute.api.globus.org",
+              "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+            },
+            "method": "GET",
+            "url": "https://compute.api.globus.org/some-resource?foo=bar",
+          }
+        `);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,8 @@ export * as gcs from './services/globus-connect-server/index.js';
 export * as timer from './services/timer/index.js';
 export * as compute from './services/compute/index.js';
 
+export { serviceRequest as request } from './services/shared.js';
+
 /**
  * Applications
  */


### PR DESCRIPTION
This PR exports our internal `serviceRequest` generator method as `request` as a way for consumers to compose requests to supported services that will use the same processing as "officially supported" methods.

For example, we are currently lacking many methods for https://timer.automate.globus.org/redoc#tag/jobs (sc-41746), which can now be expressed as:

```ts
import { request } from '@globus/sdk';

const jobs = await request({ service: 'COMPUTE', path: '/jobs' }, { headers: { Authorization: "..." }} );
```

To use an `AuthorizationManager` instance, its a little more involved...


```ts
import { request } from "@globus/sdk";
const jobs = await request(
  {
    service: "COMPUTE",
    path: "/jobs",
    resource_server: "524230d7-ea86-4a52-8312-86065a9e0417",
  },
  {},
  { authorization }
);
```

You can _technically_ get those magic-like strings from the SDK too, although I'm not sure it's that much better:

```ts
import { request, compute, auth } from "@globus/sdk";
const jobs = await request(
  {
    service: compute.CONFIG.ID,
    path: "/jobs",
    resource_server: auth.CONFIG.RESOURCE_SERVER.COMPUTE,
  },
  {},
  { authorization }
);
```


[sc-24920]
