### PR TITLE
fix(Typescript): use BaseServiceMethodOptions in ServiceMethodDynamicSegments

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -102,18 +102,12 @@ export type ServiceMethodDynamicSegments<
   HasRequiredMethodOptions<O> extends true
     ? (
         segments: S,
-        methodOptions: O & {
-          query?: BaseServiceMethodOptions['query'];
-          headers?: BaseServiceMethodOptions['headers'];
-        },
+        methodOptions: O & BaseServiceMethodOptions,
         sdkOptions?: SDKOptions,
       ) => Promise<R>
     : (
         segments: S,
-        methodOptions?: O & {
-          query?: BaseServiceMethodOptions['query'];
-          headers?: BaseServiceMethodOptions['headers'];
-        },
+        methodOptions?: O & BaseServiceMethodOptions,
         sdkOptions?: SDKOptions,
       ) => Promise<R>;
 


### PR DESCRIPTION
The change made in 72a3c49e8b81418201a7df475eef83bbb42bb6cc is now missing the other properties. I checked the following in the ts playground, so I think this will leave the required fields required and the optional fields optional.

```ts
type A = {
  a?: unknown;
  b?: unknown;
}

type B = {
  b: unknown;
}

const b: A & B = {
  b: 'b'; // commenting this out should cause a type error
}
```