### PR TITLE
chore(Search, Typescript): Fix for Search methods not allowing passing of shared service method options.

### DIFF
--- a/src/services/search/service/query.ts
+++ b/src/services/search/service/query.ts
@@ -1,7 +1,7 @@
 import { HTTP_METHODS, serviceRequest } from '../../shared.js';
 import { ID, SCOPES } from '../config.js';
 
-import type { JSONFetchResponse, SDKOptions } from '../../types.js';
+import type { JSONFetchResponse, SDKOptions, ServiceMethodOptions } from '../../types.js';
 import type { OpenAPI } from '../index.js';
 import type { ResultFormatVersion } from '../types.js';
 
@@ -54,7 +54,7 @@ export type GSearchResult<C extends Content = Content> = {
  */
 export const get = function <C extends Content = Content>(
   index_id: string,
-  options?: {
+  options?: ServiceMethodOptions & {
     /**
      * @see https://docs.globus.org/api/search/reference/get_query/#parameters
      */
@@ -105,7 +105,7 @@ export type GSearchRequest = {
  */
 export const post = function <C extends Content = Content>(
   index_id: string,
-  options: {
+  options: ServiceMethodOptions & {
     payload: GSearchRequest;
   },
   sdkOptions?: SDKOptions,


### PR DESCRIPTION
The previous definition here was causing Typescript errors when passing SDK-supported method options (e.g. `headers`)

<img width="490" height="131" alt="Screenshot 2026-01-05 at 1 12 46 PM" src="https://github.com/user-attachments/assets/29e3b990-8cd6-4f04-8ef8-b34334b994d7" />


Since these methods do not use the `satisfies ServiceMethodDynamicSegments` (and return their own Generic) the type needs to be explicitly defined.


