### PR TITLE
chore(Transfer, TypeScript): fix event list response types

### DIFF
--- a/src/services/transfer/service/task.ts
+++ b/src/services/transfer/service/task.ts
@@ -232,7 +232,7 @@ export type EventDocument = {
 };
 
 export type TaskEventListDocument = {
-  DATA_TYPE: 'task_event_list';
+  DATA_TYPE: 'event_list';
   DATA: EventDocument[];
 };
 

--- a/src/services/transfer/types.ts
+++ b/src/services/transfer/types.ts
@@ -89,7 +89,8 @@ export type Pagination = {
     Response: {
       limit: number;
       offset: number;
-      has_next_page: `${boolean}` | boolean;
+      has_next_page?: `${boolean}` | boolean;
+      total?: number;
     };
   };
   /**


### PR DESCRIPTION
The Transfer service returns a `total` property from both the user and endpoint-manager `/event_list` endpoints. This value is *not* included in some other responses that use [offset paging](https://docs.globus.org/api/transfer/overview/#offset_paging).

Similarly, the `event_list` responses do *not* include `has_next_page`, so I've marked it as optional.

Finally, the `DATA_TYPE` property from this endpoint was not quite correct.